### PR TITLE
Wire up loadType, fix progression engine bug, fix retro timezone

### DIFF
--- a/components/ForgeApp.jsx
+++ b/components/ForgeApp.jsx
@@ -17,13 +17,14 @@ import {
   checkProfileExists, claimProfile, blobDelete,
   roundPlate, applyRpe, weeksSince, weekKey,
   newDraftLog, logSet, finaliseDraft, scaleForReadiness, D, TS,
-  inferLoadType, LOAD_TYPES,
+  inferLoadType, LOAD_TYPES, startingWeightForLift,
 } from "@/lib/storage";
 import { T } from "@/lib/tokens";
 import {
   computeNextPrescription,
   updateLiftStateFromSession,
   updateMuscleAnchorFromSession,
+  reconcileLiftStateWithSession,
   // Phase 3
   shouldOfferDeload,
   computeDeloadPrescription,
@@ -73,6 +74,25 @@ function formatAgo(ms) {
 function getLoadType(ex) {
   return ex?.loadType || inferLoadType(ex?.name);
 }
+
+// ─── loadType → caption ──────────────────────────────────────────────────────
+// What does the number the user types represent? Resolves the per-DB vs
+// total-load ambiguity the picker has historically left implicit. Two
+// vocabularies coexist: programme.js entries carry "barbell"/"per_db"/
+// "total"/"machine"/"loaded_bw"/"bodyweight"; storage.js inference can
+// also produce "external"/"loaded_bodyweight"/"assisted_bodyweight" for
+// exercises without an explicit programme.js loadType. We cover both.
+// "bodyweight" intentionally has no caption — the picker hides the weight
+// field entirely for those.
+const WEIGHT_CAPTIONS = {
+  barbell:               "weight on the bar",
+  per_db:                "weight per dumbbell",
+  total:                 "total weight",
+  machine:               "machine stack weight",
+  loaded_bw:             "added weight",
+  loaded_bodyweight:     "added weight",
+  assisted_bodyweight:   "band assistance",
+};
 
 // ─── ScrollDrum ────────────────────────────────────────────────────────────────
 function ScrollDrum({value,onChange,step=1.25,min=0,max=500,integer=false,label="",unit=null}){
@@ -589,7 +609,19 @@ export default function ForgeApp(){
   const resolvedEx  = !isSS ? resolveExFn(block.id, null, block.ex) : null;
   const activeEx    = isSS ? (phase==="A" ? resolvedExA : resolvedExB) : resolvedEx;
 
-  const getW=useCallback((ex)=>ex?(workingWeights[ex.name]??ex.weight):null,[workingWeights]);
+  // Resolution order for prescribed weight:
+  //   1. workingWeights[ex.name]  — engine-driven progression from prior sessions
+  //   2. startingWeightForLift(ex.name, bodyweight) — BW% floor for main lifts
+  //      on first-session cold start (only fires for the 5 mains, and only
+  //      when bodyweight has been captured)
+  //   3. ex.weight — the hardcoded SESSIONS default
+  const getW=useCallback((ex)=>{
+    if (!ex) return null;
+    if (workingWeights[ex.name] !== undefined) return workingWeights[ex.name];
+    const bwSeeded = startingWeightForLift(ex.name, bodyweight);
+    if (bwSeeded !== null) return bwSeeded;
+    return ex.weight;
+  },[workingWeights, bodyweight]);
   const getR=useCallback((ex)=>ex?(workingReps[ex.name]??ex.reps):null,[workingReps]);
 
   const onSwap=useCallback((key, newEx)=>{
@@ -616,6 +648,13 @@ export default function ForgeApp(){
     const swapped  = !!swapPick;
     const fromPool = EXERCISE_POOLS[key] ? key : null;
     const loadType = getLoadType(ex);
+    // Mirror getW's resolution order so the LOGGED weight matches what was
+    // DISPLAYED to the user. Critical for main lifts on first session — the
+    // user sees the BW-seeded weight but if we logged ex.weight (the old
+    // hardcoded default) the engine would reason from a phantom number.
+    const resolvedWeight = workingWeights[ex.name]
+      ?? startingWeightForLift(ex.name, bodyweight)
+      ?? ex.weight;
     logSet(draftLogRef.current, {
       blockId: block.id,
       blockType: block.type,
@@ -625,7 +664,7 @@ export default function ForgeApp(){
       fromPool,
       loadType,
       bodyweight: bodyweight,
-      weight: workingWeights[ex.name] ?? ex.weight,
+      weight: resolvedWeight,
       reps: workingReps[ex.name] ?? ex.reps,
       rpe: rpe || null,
     });
@@ -763,7 +802,14 @@ export default function ForgeApp(){
 
           for (const block of sessionRecord.blocks || []) {
             for (const ex of block.exercises || []) {
-              const liftState = trainingState.lifts?.[ex.name] || null;
+              // Reconcile liftState.currentWeight with what was actually
+              // performed BEFORE computing the prescription. A stale seed
+              // (programme default, or a prior session's adjusted-down weight
+              // that the user has since dialled further) otherwise overrides
+              // the engine's reasoning basis and "HOLD" prescriptions surface
+              // at the old number instead of what the user just lifted.
+              const rawLiftState = trainingState.lifts?.[ex.name] || null;
+              const liftState    = reconcileLiftStateWithSession(rawLiftState, ex);
               const profile = getLiftProfile(ex.name);
               const anchorMuscle = profile.primaryMuscle;
               const muscleAnchor = anchorMuscle
@@ -1209,7 +1255,9 @@ const sProps={
 
         for (const block of sessionRecord.blocks || []) {
           for (const ex of block.exercises || []) {
-            const liftState     = trainingState.lifts?.[ex.name] || null;
+            // Reconcile before reading — see same comment on the live path.
+            const rawLiftState  = trainingState.lifts?.[ex.name] || null;
+            const liftState     = reconcileLiftStateWithSession(rawLiftState, ex);
             const profile       = getLiftProfile(ex.name);
             const anchorMuscle  = profile.primaryMuscle;
             const muscleAnchor  = anchorMuscle
@@ -2941,11 +2989,15 @@ function ReadinessScreen({readiness,setReadiness,reason,setReason,onStart}){
 }
 
 // ─── RPE Card ─────────────────���────────────────────────────────────────────────
+// Per-set effort picker. Three-point scale: easy / normal / cooked.
+// Maps to RIR via rpeToRir in storage.js: easy=3, normal=2, cooked=0.
+// The legacy hard/limit scale is only kept as a read-time alias inside
+// rpeToRir for v1 records — it must NOT appear in any UI.
 function RpeCard({onPick,label="How was that set?"}){
   const opts=[
-    {id:"easy", icon:"😮‍💨",label:"Easy", sub:"More in the tank",color:T.sage},
-    {id:"hard", icon:"😤", label:"Hard", sub:"Close to limit",   color:T.gold},
-    {id:"limit",icon:"🔥", label:"Limit",sub:"Max effort",       color:T.rose},
+    {id:"easy",  icon:"😮‍💨",label:"Easy",  sub:"More in the tank",color:T.sage},
+    {id:"normal",icon:"😤", label:"Normal",sub:"Working effort",   color:T.gold},
+    {id:"cooked",icon:"🔥", label:"Cooked",sub:"Max effort",       color:T.rose},
   ];
   return (
     <div style={{margin:"14px 20px 0",background:T.bg2,border:`1px solid ${T.bg3}`,borderRadius:T.r.lg,padding:"16px 18px",animation:`fadeSlide 240ms ${T.ease}`}}>
@@ -2981,13 +3033,18 @@ function SessionScreen({session,block,blockIdx,totalBlocks,setNum,phase,isSS,act
   // Load type handling for bodyweight movements
   const loadType = getLoadType(activeEx);
   const showWeightPicker = loadType !== "bodyweight";
-  const weightLabel = loadType === "loaded_bodyweight" ? "+ kg"
+  const weightLabel = loadType === "loaded_bodyweight" || loadType === "loaded_bw" ? "+ kg"
                     : loadType === "assisted_bodyweight" ? "− kg"
                     : "kg";
   const loadTypeSubtitle = loadType === "bodyweight" ? "Bodyweight"
-                         : loadType === "loaded_bodyweight" ? "Added load"
+                         : loadType === "loaded_bodyweight" || loadType === "loaded_bw" ? "Added load"
                          : loadType === "assisted_bodyweight" ? "Band assist"
                          : null;
+  // Caption telling the user what the entered weight represents. Resolves
+  // the per-dumbbell-vs-total ambiguity that's been ambiguous in the UI so
+  // far. Drives off the programme.js loadType vocabulary plus the
+  // storage.js loadType vocabulary (both can appear via getLoadType).
+  const weightCaption = WEIGHT_CAPTIONS[loadType] || null;
 
   return (
     <div style={{minHeight:"100vh",position:"relative",overflow:"hidden",paddingBottom:40}}>
@@ -3035,11 +3092,16 @@ function SessionScreen({session,block,blockIdx,totalBlocks,setNum,phase,isSS,act
           )}
         </div>
         {showWeightPicker && currentW!==null&&(
-          <div style={{display:"flex",alignItems:"baseline",gap:8,marginBottom:4,cursor:"pointer",userSelect:"none"}} onClick={()=>{ if(activeEx?.name) setEditTarget({exName:activeEx.name,currentKg:currentW,currentReps:getR(activeEx),loadType}); }}>
-            <span style={{fontFamily:T.serif,fontSize:80,fontWeight:300,color:T.text1,lineHeight:1,letterSpacing:"-0.02em"}}>{currentW}</span>
-            <span style={{fontFamily:T.serif,fontSize:22,fontWeight:300,color:T.text3,marginBottom:8}}>{weightLabel}</span>
-            <span style={{fontSize:11,color:T.text3,marginBottom:10,marginLeft:4}}>↕</span>
-          </div>
+          <>
+            <div style={{display:"flex",alignItems:"baseline",gap:8,marginBottom:4,cursor:"pointer",userSelect:"none"}} onClick={()=>{ if(activeEx?.name) setEditTarget({exName:activeEx.name,currentKg:currentW,currentReps:getR(activeEx),loadType}); }}>
+              <span style={{fontFamily:T.serif,fontSize:80,fontWeight:300,color:T.text1,lineHeight:1,letterSpacing:"-0.02em"}}>{currentW}</span>
+              <span style={{fontFamily:T.serif,fontSize:22,fontWeight:300,color:T.text3,marginBottom:8}}>{weightLabel}</span>
+              <span style={{fontSize:11,color:T.text3,marginBottom:10,marginLeft:4}}>↕</span>
+            </div>
+            {weightCaption && (
+              <div style={{fontSize:11,color:T.text4,fontStyle:"italic",fontFamily:T.serif,marginBottom:4}}>{weightCaption}</div>
+            )}
+          </>
         )}
         <div style={{display:"flex",alignItems:"baseline",gap:6,cursor:"pointer",userSelect:"none"}} onClick={()=>{ if(activeEx?.name) setEditTarget({exName:activeEx.name,currentKg:showWeightPicker?currentW:null,currentReps:getR(activeEx),loadType}); }}>
           <span style={{fontFamily:T.serif,fontSize:48,fontWeight:400,color:T.coral,lineHeight:1,fontStyle:"italic"}}>{getR(activeEx)}</span>
@@ -3403,7 +3465,11 @@ function RetrospectiveSessionSheet({date, bodyweight, workingWeights, workingRep
   // first-cell auto-fill only propagates to cells the user hasn't touched.
   const [entries, setEntries] = useState(() => exerciseRows.map(ex => {
     const setCount = ex.sets || 3;
-    const baseWeight = workingWeights[ex.name] ?? ex.weight ?? null;
+    // Same resolution order as the live session's getW: working → BW-seeded → SESSIONS default.
+    const baseWeight = workingWeights[ex.name]
+      ?? startingWeightForLift(ex.name, bodyweight)
+      ?? ex.weight
+      ?? null;
     const baseReps   = workingReps[ex.name] ?? ex.reps ?? null;
     const lt = getLoadType(ex);
     return {

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -14,6 +14,24 @@ export function epley1RM(weight, reps) {
   return Math.round(weight * (1 + reps / 30) * 10) / 10;
 }
 
+// ─── Systemic-load multiplier per loadType ───────────────────────────────────
+// What the user types vs. what their body actually moved.
+//
+//   per_db    → user enters per-dumbbell weight; both hands contribute, so
+//               systemic load is 2× the entered number for volume purposes.
+//   everything else → entered weight === systemic load (1×).
+//
+// Why volume only (not 1RM): 1RM is a single-limb capacity number tied to
+// the implement the user actually held, so the per-DB number IS the right
+// 1RM input. Volume aggregates total work done per session — for a 20kg DB
+// curl × 10 reps both arms, the body did 400kg of work, not 200kg.
+//
+// Used by both weeklyVolume and aggregateVolume so per-muscle distribution
+// charts don't under-count every dumbbell exercise by half.
+function loadTypeMultiplier(loadType) {
+  return loadType === "per_db" ? 2 : 1;
+}
+
 // ─── Main lift trend ──────────────────────────────────────────────────────────
 // Returns { [exerciseName]: [{ date, est1RM, topSet:{weight,reps,rpe} }] }
 // Only includes exercises logged in "main" blocks. Skips sessions marked cooked
@@ -79,16 +97,21 @@ export function weeklyVolume(history) {
         if (!byWeek[weekStart][muscle]) byWeek[weekStart][muscle] = { sets: 0, volume: 0 };
         for (const s of ex.sets || []) {
           byWeek[weekStart][muscle].sets += 1;
+          // Per-DB exercises (e.g. DB curl, lateral raise) are logged with
+          // the per-dumbbell number; systemic load is 2× that across both
+          // hands. Cached volume was computed pre-multiplier, so we apply
+          // it consistently in both branches.
+          const mult = loadTypeMultiplier(s.loadType ?? ex.loadType);
           // Prefer cached volume (Phase 0.5+ records carry it as set.volume,
           // computed using effectiveLoad so BW movements are tracked correctly).
           // Fall back to raw weight × reps for legacy v1 records.
           if (s.volume != null) {
-            byWeek[weekStart][muscle].volume += s.volume;
+            byWeek[weekStart][muscle].volume += s.volume * mult;
           } else {
             const reps = parseReps(s.reps);
             const load = s.effectiveLoad ?? s.weight;
             if (load && reps) {
-              byWeek[weekStart][muscle].volume += load * reps;
+              byWeek[weekStart][muscle].volume += load * reps * mult;
             }
           }
         }
@@ -280,13 +303,16 @@ function aggregateVolume(records) {
         if (!muscle) continue;
         if (!byMuscle[muscle]) byMuscle[muscle] = 0;
         for (const s of ex.sets || []) {
+          // Per-DB exercises log per-dumbbell weight; systemic load 2× —
+          // see loadTypeMultiplier comment for rationale.
+          const mult = loadTypeMultiplier(s.loadType ?? ex.loadType);
           let v;
           if (s.volume != null) {
-            v = s.volume;
+            v = s.volume * mult;
           } else {
             const reps = parseReps(s.reps);
             const load = s.effectiveLoad ?? s.weight;
-            v = (load && reps) ? load * reps : 0;
+            v = (load && reps) ? load * reps * mult : 0;
           }
           byMuscle[muscle] += v;
           total += v;

--- a/lib/programme.js
+++ b/lib/programme.js
@@ -41,7 +41,7 @@ export const SESSIONS = [
         exB:{ name:"Landmine Press",          reps:10,     weight:28,  muscle:"Upper chest",       vid:"QMrm2WMbj3k", loadType:"barbell" }},
       { id:"afin",type:"finisher",  label:"Finisher",            sets:2, rest:60,
         exA:{ name:"Hanging Leg Raise",       reps:10,     weight:null,muscle:"Core",              vid:"hdng3Nm1x_E", loadType:"bodyweight" },
-        exB:{ name:"Standing Calf Raise",     reps:10,     weight:35,  muscle:"Calves",            vid:"3UWi44yN-wM", loadType:"machine" }},
+        exB:{ name:"Standing Calf Raise",     reps:15,     weight:35,  muscle:"Calves",            vid:"3UWi44yN-wM", loadType:"machine" }},
     ],
   },
   // ── B · Wednesday · Hinge + Pull ──────────────────────────────────────────
@@ -137,15 +137,15 @@ export const EXERCISE_POOLS = {
     { name:"Floor Press",            reps:10,      weight:45,  muscle:"Upper chest",      vid:null, loadType:"barbell" },
   ]},
   "afin-A":{ gripDemand:"HIGH", zone:"bodyweight", pool:[
-    { name:"Hanging Leg Raise",      reps:10,      weight:null,muscle:"Core",              vid:"hdng3Nm1x_E" },
-    { name:"Toes-to-Bar",            reps:8,       weight:null,muscle:"Core",              vid:null },
-    { name:"Captain's Chair Raise",  reps:12,      weight:null,muscle:"Core",              vid:null },
-    { name:"Hanging Knee Raise",     reps:12,      weight:null,muscle:"Core",              vid:null },
-    { name:"L-Sit Hold",             reps:"20s",   weight:null,muscle:"Core",              vid:null },
-    { name:"Windshield Wiper",       reps:8,       weight:null,muscle:"Core",              vid:null },
+    { name:"Hanging Leg Raise",      reps:10,      weight:null,muscle:"Core",              vid:"hdng3Nm1x_E", loadType:"bodyweight" },
+    { name:"Toes-to-Bar",            reps:8,       weight:null,muscle:"Core",              vid:null, loadType:"bodyweight" },
+    { name:"Captain's Chair Raise",  reps:12,      weight:null,muscle:"Core",              vid:null, loadType:"bodyweight" },
+    { name:"Hanging Knee Raise",     reps:12,      weight:null,muscle:"Core",              vid:null, loadType:"bodyweight" },
+    { name:"L-Sit Hold",             reps:"20s",   weight:null,muscle:"Core",              vid:null, loadType:"bodyweight" },
+    { name:"Windshield Wiper",       reps:8,       weight:null,muscle:"Core",              vid:null, loadType:"bodyweight" },
   ]},
   "afin-B":{ gripDemand:"NONE", zone:"machine", pool:[
-    { name:"Standing Calf Raise",    reps:15,      weight:40,  muscle:"Calves",            vid:"-M4-G8p8fmc", loadType:"machine" },
+    { name:"Standing Calf Raise",    reps:15,      weight:35,  muscle:"Calves",            vid:"3UWi44yN-wM", loadType:"machine" },
     { name:"Seated Calf Raise",      reps:15,      weight:35,  muscle:"Calves",            vid:null, loadType:"machine" },
     { name:"Smith Calf Raise",       reps:15,      weight:40,  muscle:"Calves",            vid:null, loadType:"machine" },
     { name:"Single-Leg Calf Raise",  reps:"15/leg",weight:null,muscle:"Calves",            vid:null, loadType:"bodyweight" },
@@ -504,6 +504,22 @@ export function sessionMetaForDate(dateStr) {
   };
 }
 
+// Format a Date as a LOCAL-timezone "YYYY-MM-DD" string. Critical: do NOT
+// use `Date.toISOString().slice(0, 10)` here. toISOString shifts to UTC, so
+// for UK users in BST (UTC+1) at any time during the day, the UTC date is
+// usually the same but at midnight local (00:00 BST = 23:00 UTC the day
+// before) the date string would be yesterday's, not today's. Worse: when
+// walking back N days from local midnight, every dateStr off by one in
+// the timezone-positive direction. That's how a Saturday-morning check-in
+// for a missed Friday workout ended up showing Thursday/Wed/Tue instead of
+// Fri/Thu/Wed. Use local components throughout.
+function localDateStr(d) {
+  const yyyy = d.getFullYear();
+  const mm   = String(d.getMonth() + 1).padStart(2, "0");
+  const dd   = String(d.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
 // Walk back N calendar days (excluding today) and return rows describing what
 // was scheduled and whether it was logged. Caller decides what to do with each
 // row (render dim, render tappable, render "view session", etc).
@@ -518,7 +534,8 @@ export function findRecentDays(history = [], daysBack = 3, { order = "desc" } = 
   if (daysBack < 1) return [];
   const today    = new Date();
   today.setHours(0, 0, 0, 0);
-  const todayStr = today.toISOString().slice(0, 10);
+  // LOCAL date string — see localDateStr note above.
+  const todayStr = localDateStr(today);
 
   const loggedDates = new Map();
   for (const rec of history) {
@@ -532,7 +549,7 @@ export function findRecentDays(history = [], daysBack = 3, { order = "desc" } = 
   for (let i = 1; i <= daysBack; i++) {
     const d = new Date(today);
     d.setDate(d.getDate() - i);
-    const dateStr = d.toISOString().slice(0, 10);
+    const dateStr = localDateStr(d);
     const meta    = sessionMetaForDate(dateStr);
     if (!meta) continue;
     rows.push({

--- a/lib/progression.js
+++ b/lib/progression.js
@@ -181,12 +181,24 @@ function topSetRir(exercise) {
 // ─── Get the top-set effective load ──────────────────────────────────────────
 // Returns the heaviest set's effectiveLoad if available (reflects true systemic
 // load including bodyweight for non-external lifts).
+//
+// CRITICAL: fallbackWeight is used ONLY when the exercise has no performable
+// loads (no sets, or all-zero bodyweight sets). It must NOT be max-blended
+// with actual performed loads — doing so makes a stale liftState.currentWeight
+// override the user's just-performed lighter top set, so the engine reasons
+// from a phantom basis. That bug surfaced as "I logged 100kg max-effort
+// after dropping the bar weight in-session, but next session jumped to 110kg"
+// when liftState.currentWeight was still seeded from the old hardcoded
+// SESSIONS default.
 function topSetWeight(exercise, fallbackWeight) {
   const sets = exercise.sets || [];
   if (sets.length === 0) return fallbackWeight;
   // Prefer effectiveLoad (Phase 0.5+); fall back to raw weight
-  const loads = sets.map(s => s.effectiveLoad ?? s.weight ?? 0);
-  return Math.max(...loads, fallbackWeight ?? 0) || fallbackWeight;
+  const loads = sets
+    .map(s => s.effectiveLoad ?? s.weight ?? 0)
+    .filter(l => l > 0);
+  if (loads.length === 0) return fallbackWeight; // all-zero (BW only)
+  return Math.max(...loads);
 }
 
 // ─── Decide ADD / HOLD / DROP based on performance + RIR ─────────────────────
@@ -541,6 +553,28 @@ export function updateMuscleAnchorFromSession(currentAnchor, sessionRecord, exer
     bestE1RMDate,
     recentTopSets,
   };
+}
+
+// ─── Reconcile liftState with what was actually performed ─────────────────────
+// Returns a new liftState with currentWeight overwritten to the top-set weight
+// just performed in this session's exercise. Used by the finalise pipeline to
+// ensure the progression engine reasons from what the user actually lifted,
+// not from a stale seed (programme default, or an old in-session adjustment
+// that was further dialled down).
+//
+// Pure function. Returns the input untouched when nothing was performed
+// (e.g. all-bodyweight sets with no fallback). Returns null if liftState
+// is null (caller should leave it alone in that case).
+export function reconcileLiftStateWithSession(liftState, exercise) {
+  if (!liftState) return liftState;
+  const sets = exercise?.sets || [];
+  const loads = sets
+    .map(s => s.effectiveLoad ?? s.weight ?? 0)
+    .filter(l => l > 0);
+  if (loads.length === 0) return liftState; // nothing loaded to reconcile from
+  const performedTopSet = Math.max(...loads);
+  if (performedTopSet === liftState.currentWeight) return liftState;
+  return { ...liftState, currentWeight: performedTopSet };
 }
 
 // Test exports

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -537,6 +537,37 @@ export function applyRpe(weight, rpe) {
   return weight; // "hard" — hold weight, don't adjust
 }
 
+// ─── BW-percentage starting weights for the 5 main lifts ─────────────────────
+// Replaces the hardcoded SESSIONS defaults for first-session prescription.
+// Multipliers are evidence-based intermediate-novice floors (Israetel/Helms),
+// rounded to the nearest 2.5kg. Barbell lifts are floored at 20kg (empty bar).
+//
+// Returns null when bodyweight isn't captured — caller falls back to the
+// programme.js SESSIONS default for that lift.
+export const MAIN_LIFT_BW_MULTIPLIERS = {
+  "Hex Bar Deadlift":       1.00,
+  "Barbell Back Squat":     0.75,
+  "Barbell Bench Press":    0.65,
+  "Barbell Overhead Press": 0.40,
+  "Power Clean":            0.50,
+};
+
+// Round to the nearest 2.5kg — standard plate-loadable increment.
+export function roundToHalfPlate(kg) {
+  return Math.round(kg / 2.5) * 2.5;
+}
+
+export function startingWeightForLift(liftName, bodyweightKg) {
+  if (!liftName) return null;
+  if (bodyweightKg === null || bodyweightKg === undefined) return null;
+  const mult = MAIN_LIFT_BW_MULTIPLIERS[liftName];
+  if (!mult) return null;
+  const raw = bodyweightKg * mult;
+  const rounded = roundToHalfPlate(raw);
+  // Empty-bar floor on barbell lifts — all five mains here are barbell.
+  return Math.max(20, rounded);
+}
+
 // ─── Time utilities ───────────────────────────────────────────────────────────
 export function weeksSince(dateStr) {
   return Math.floor((Date.now() - new Date(dateStr).getTime()) / (7 * 86400000));

--- a/tests/analytics.test.js
+++ b/tests/analytics.test.js
@@ -1,0 +1,164 @@
+// tests/analytics.test.js
+// ────────────────────────────────────────────────────────────────────────────
+// Volume aggregation correctness.
+//
+// Coverage focus:
+//   1. per_db exercises double for volume (DB curl × 10kg × 10 reps both arms
+//      = 200kg systemic load, not 100kg). Without this, every dumbbell
+//      exercise is under-counted by half in per-muscle distribution charts.
+//   2. Non-per_db loadTypes don't double (1×).
+//   3. Legacy records without loadType default to 1× (don't retro-multiply).
+// ────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect } from "vitest";
+import { weeklyVolume, __test_p4__ } from "../lib/analytics.js";
+
+const { aggregateVolume } = __test_p4__;
+
+function buildSet({ weight = 10, reps = 10, loadType = null, volume = null, effectiveLoad = null }) {
+  return {
+    weight,
+    reps,
+    rir: 2,
+    loadType,
+    effectiveLoad: effectiveLoad ?? weight,
+    volume: volume,
+  };
+}
+
+function buildSession({ date = "2026-04-27", exercises = [] }) {
+  return {
+    v: 2,
+    id: `${date}T10:00:00.000Z`,
+    date,
+    readiness: "normal",
+    blocks: [{ id: "x", type: "main", exercises }],
+  };
+}
+
+describe("aggregateVolume — per_db loadType doubles", () => {
+  it("doubles volume for per_db exercise when set has loadType=per_db", () => {
+    const session = buildSession({
+      exercises: [{
+        name: "DB Curl",
+        muscle: "Biceps",
+        loadType: "per_db",
+        sets: [
+          buildSet({ weight: 10, reps: 10, loadType: "per_db", volume: 100 }),
+          buildSet({ weight: 10, reps: 10, loadType: "per_db", volume: 100 }),
+          buildSet({ weight: 10, reps: 10, loadType: "per_db", volume: 100 }),
+        ],
+      }],
+    });
+    const result = aggregateVolume([session]);
+    // 3 sets × (10kg × 10 reps × 2 hands) = 600
+    expect(result.byMuscle.Biceps).toBe(600);
+    expect(result.total).toBe(600);
+  });
+
+  it("doubles via exercise-level loadType when sets lack loadType (legacy records)", () => {
+    // v1 records: per-set loadType absent; rely on exercise-level loadType.
+    // Use a muscle label that doesn't accidentally normalise to Back via the
+    // existing "lat" substring rule (e.g. "Lateral delt" → "Back").
+    const session = buildSession({
+      exercises: [{
+        name: "Lateral Raise",
+        muscle: "Shoulders",
+        loadType: "per_db",
+        sets: [
+          buildSet({ weight: 8, reps: 15, loadType: null, volume: 120 }),
+          buildSet({ weight: 8, reps: 15, loadType: null, volume: 120 }),
+        ],
+      }],
+    });
+    const result = aggregateVolume([session]);
+    // 2 × (8 × 15 × 2) = 480
+    expect(result.byMuscle.Shoulders).toBe(480);
+  });
+
+  it("does NOT double for barbell loadType", () => {
+    const session = buildSession({
+      exercises: [{
+        name: "Barbell Back Squat",
+        muscle: "Quadriceps",
+        loadType: "barbell",
+        sets: [
+          buildSet({ weight: 100, reps: 5, loadType: "barbell", volume: 500 }),
+        ],
+      }],
+    });
+    const result = aggregateVolume([session]);
+    expect(result.byMuscle.Legs).toBe(500); // 1×
+  });
+
+  it("does NOT double for machine, total, loaded_bw, or bodyweight loadTypes", () => {
+    const session = buildSession({
+      exercises: [
+        {
+          name: "Leg Press", muscle: "Quadriceps", loadType: "machine",
+          sets: [buildSet({ weight: 100, reps: 10, loadType: "machine", volume: 1000 })],
+        },
+        {
+          name: "Cable Pull-Through", muscle: "Glutes", loadType: "total",
+          sets: [buildSet({ weight: 50, reps: 10, loadType: "total", volume: 500 })],
+        },
+      ],
+    });
+    const result = aggregateVolume([session]);
+    expect(result.byMuscle.Legs).toBe(1500); // 1000 + 500
+  });
+
+  it("legacy records without any loadType default to 1× (no retro-multiplier)", () => {
+    const session = buildSession({
+      exercises: [{
+        name: "Bench Press",
+        muscle: "Chest",
+        // no loadType on exercise or sets
+        sets: [
+          { weight: 80, reps: 5, rir: 2, volume: 400 },
+        ],
+      }],
+    });
+    const result = aggregateVolume([session]);
+    expect(result.byMuscle.Chest).toBe(400);
+  });
+
+  it("falls back to raw weight × reps × multiplier when cached volume is absent", () => {
+    const session = buildSession({
+      exercises: [{
+        name: "DB Curl",
+        muscle: "Biceps",
+        loadType: "per_db",
+        sets: [
+          { weight: 10, reps: 10, rir: 2, loadType: "per_db" }, // no volume, no effectiveLoad
+        ],
+      }],
+    });
+    const result = aggregateVolume([session]);
+    // 10 × 10 × 2 = 200
+    expect(result.byMuscle.Biceps).toBe(200);
+  });
+});
+
+describe("weeklyVolume — per_db loadType doubles", () => {
+  it("doubles DB exercise volume in weekly aggregation", () => {
+    const session = buildSession({
+      date: "2026-04-27",
+      exercises: [{
+        name: "DB Curl",
+        muscle: "Biceps",
+        loadType: "per_db",
+        sets: [
+          buildSet({ weight: 10, reps: 12, loadType: "per_db", volume: 120 }),
+          buildSet({ weight: 10, reps: 12, loadType: "per_db", volume: 120 }),
+          buildSet({ weight: 10, reps: 12, loadType: "per_db", volume: 120 }),
+        ],
+      }],
+    });
+    const weeks = weeklyVolume([session]);
+    expect(weeks.length).toBe(1);
+    // 3 × 120 × 2 = 720
+    expect(weeks[0].byMuscle.Biceps.volume).toBe(720);
+    expect(weeks[0].byMuscle.Biceps.sets).toBe(3);
+  });
+});

--- a/tests/programme.test.js
+++ b/tests/programme.test.js
@@ -1,0 +1,110 @@
+// tests/programme.test.js
+// ────────────────────────────────────────────────────────────────────────────
+// Programme data invariants.
+//
+// Coverage focus:
+//   1. Pool[0] === SESSIONS default for every accessory/finisher slot —
+//      drift here means rotation silently presents a different exercise on
+//      Day 1 than the home screen shows. Caught a Standing Calf Raise
+//      mismatch that survived a recalibration diff.
+//   2. findRecentDays time-window correctness — including local-timezone
+//      handling so UK users (BST = UTC+1 in summer) can log Friday's
+//      missed workout when they remember on Saturday.
+// ────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect } from "vitest";
+import { SESSIONS, EXERCISE_POOLS, findRecentDays } from "../lib/programme.js";
+
+// ─── Pool[0] invariant ──────────────────────────────────────────────────────
+describe("EXERCISE_POOLS pool[0] === SESSIONS default", () => {
+  // Build a flat map of slot key → SESSIONS default exercise.
+  // Keys: blockId for non-superset (e.g. "ass2"), `${blockId}-${A|B}` otherwise.
+  const sessionDefaults = {};
+  for (const sess of SESSIONS) {
+    for (const block of sess.blocks) {
+      if (block.type === "main") continue;
+      if (block.ex)  sessionDefaults[block.id] = block.ex;
+      if (block.exA) sessionDefaults[`${block.id}-A`] = block.exA;
+      if (block.exB) sessionDefaults[`${block.id}-B`] = block.exB;
+    }
+  }
+
+  // Every pool's pool[0] must equal the SESSIONS default for that slot
+  // across every field the engine reads: name, reps, weight, muscle, vid,
+  // loadType. Any drift makes the rotation engine present a different
+  // exercise on the first session of a new block than the home screen
+  // advertises, which silently invalidates muscle-anchor lookups and
+  // confuses users.
+  const fields = ["name", "reps", "weight", "muscle", "vid", "loadType"];
+
+  for (const [key, slot] of Object.entries(EXERCISE_POOLS)) {
+    it(`${key} pool[0] matches SESSIONS default on every field`, () => {
+      const def = sessionDefaults[key];
+      expect(def, `No SESSIONS default for slot ${key}`).toBeTruthy();
+      const head = slot.pool[0];
+      for (const f of fields) {
+        expect(head[f], `${key}.${f} mismatch`).toEqual(def[f]);
+      }
+    });
+  }
+});
+
+// Helper: format a Date as a local-timezone YYYY-MM-DD string.
+function fmtLocal(d) {
+  const yyyy = d.getFullYear();
+  const mm   = String(d.getMonth() + 1).padStart(2, "0");
+  const dd   = String(d.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+// ─── findRecentDays — timezone correctness ──────────────────────────────────
+describe("findRecentDays — local timezone handling", () => {
+  it("returns the expected number of rows for daysBack=3", () => {
+    const rows = findRecentDays([], 3);
+    expect(rows).toHaveLength(3);
+  });
+
+  it("excludes today; the most recent row is yesterday in LOCAL time", () => {
+    const rows = findRecentDays([], 3, { order: "asc" });
+    expect(rows).toHaveLength(3);
+    const todayLocal = fmtLocal(new Date());
+    expect(rows[rows.length - 1].date).not.toBe(todayLocal); // not today
+
+    // Yesterday — using local date arithmetic
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    expect(rows[rows.length - 1].date).toBe(fmtLocal(yesterday));
+  });
+
+  it("BST regression: when local time is morning, retro window must NOT slip a day", () => {
+    // The bug: a UK user (UTC+1 in summer) checking on Saturday morning could
+    // not see Friday in the retro picker, because the old impl used
+    // toISOString().slice(0,10) on a Date set to local midnight, which in BST
+    // converts back to the previous day in UTC. The 3-day window then
+    // surveyed Thursday/Wednesday/Tuesday instead of Friday/Thursday/Wednesday.
+    //
+    // This test asserts the picker's returned dates are in lockstep with the
+    // user's LOCAL calendar regardless of UTC offset: rows[i].date for i=1
+    // must equal "yesterday on the user's local clock," period.
+    const rows = findRecentDays([], 3, { order: "asc" });
+    const expected = [];
+    for (let i = 3; i >= 1; i--) {
+      const d = new Date();
+      d.setHours(0, 0, 0, 0);
+      d.setDate(d.getDate() - i);
+      expected.push(fmtLocal(d));
+    }
+    expect(rows.map(r => r.date)).toEqual(expected);
+  });
+
+  it("does not list today even with sessions logged today", () => {
+    const todayStr = fmtLocal(new Date());
+    const history = [{ id: `${todayStr}T10:00:00.000Z`, date: todayStr, session: "strength-a" }];
+    const rows = findRecentDays(history, 3);
+    expect(rows.find(r => r.date === todayStr)).toBeUndefined();
+  });
+
+  it("daysBack=0 returns empty list", () => {
+    expect(findRecentDays([], 0)).toEqual([]);
+  });
+});

--- a/tests/progression.test.js
+++ b/tests/progression.test.js
@@ -18,6 +18,7 @@ import { describe, it, expect } from "vitest";
 import {
   computeNextPrescription,
   updateLiftStateFromSession,
+  reconcileLiftStateWithSession,
   // Phase 3
   detectDeloadSignals,
   shouldOfferDeload,
@@ -33,6 +34,7 @@ import {
   __test__,
   __test_p3__,
 } from "../lib/progression.js";
+import { startingWeightForLift, roundToHalfPlate } from "../lib/storage.js";
 
 // ─── Test helpers ───────────────────────────────────────────────────────────
 function buildSet({ weight = 100, reps = 5, rir = 2, effectiveLoad = null, volume = null }) {
@@ -678,5 +680,185 @@ describe("Internal helpers (__test__)", () => {
       ],
     });
     expect(__test__.topSetRir(ex)).toBe(1);
+  });
+
+  it("topSetWeight returns actual performed top set, NOT max-blended with stale fallback", () => {
+    // Regression test for the engine bug: previously topSetWeight did
+    //   Math.max(...loads, fallbackWeight)
+    // which let a stale liftState.currentWeight override what the user just
+    // performed. Now actual performed loads always win; fallback is used
+    // only when no loads were performed.
+    const ex = buildExercise({
+      sets: [
+        buildSet({ weight: 80, reps: 5, rir: 1 }),
+        buildSet({ weight: 80, reps: 5, rir: 1 }),
+        buildSet({ weight: 80, reps: 5, rir: 1 }),
+      ],
+    });
+    // stale fallback = 110, actual performed = 80. We expect 80.
+    expect(__test__.topSetWeight(ex, 110)).toBe(80);
+  });
+
+  it("topSetWeight uses fallback only when sets are empty or all-zero", () => {
+    const empty = buildExercise({ sets: [] });
+    expect(__test__.topSetWeight(empty, 100)).toBe(100);
+
+    const allZero = buildExercise({
+      sets: [
+        buildSet({ weight: null, reps: 5, rir: 2, effectiveLoad: 0 }),
+        buildSet({ weight: null, reps: 5, rir: 2, effectiveLoad: 0 }),
+      ],
+    });
+    expect(__test__.topSetWeight(allZero, 75)).toBe(75);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// 9. Engine bug — full path: stale liftState seed + in-session dial-down
+//    must HOLD at the actually-performed weight, not "ADD" off the stale basis.
+// ────────────────────────────────────────────────────────────────────────────
+describe("Engine bug — stale liftState seed reconciliation", () => {
+  it("HOLDs at performed weight when user dials DOWN in-session and grinds it out", () => {
+    // Scenario: user has stale liftState.currentWeight = 110 (from old
+    // hardcoded SESSIONS default before recalibration). They adjust DOWN
+    // in-session to 100kg, perform 100kg × 5 at max effort (rir=0). The
+    // engine MUST recognise that 100kg is the actual basis — not max-blend
+    // with the stale 110 number.
+    const lastSession = buildSession({
+      readiness: "normal",
+      exercises: [buildExercise({
+        name: "Barbell Back Squat",
+        sets: [
+          buildSet({ weight: 100, reps: 5, rir: 0 }), // max effort
+          buildSet({ weight: 100, reps: 5, rir: 0 }),
+          buildSet({ weight: 100, reps: 5, rir: 0 }),
+        ],
+        prescribed: { sets: 3, reps: 5, weight: 100 },
+      })],
+    });
+    const staleLiftState = {
+      currentWeight: 110,                      // stale seed
+      currentRepRange: { reps: 5, sets: 3 },
+      bestE1RM: 117,
+      consecutiveHolds: 0,
+      stallSignal: null,
+      history: [],
+    };
+    // Reconcile (mirrors ForgeApp's finalise pipeline)
+    const reconciled = reconcileLiftStateWithSession(
+      staleLiftState,
+      lastSession.blocks[0].exercises[0],
+    );
+    expect(reconciled.currentWeight).toBe(100); // reconciled to actual
+
+    const result = computeNextPrescription({
+      liftName: "Barbell Back Squat",
+      history: [lastSession],
+      liftState: reconciled,
+      muscleAnchor: null,
+      context: { readiness: "normal", currentWeight: 100 },
+    });
+    // rir=0 grinder → HOLD; weight must be the actually-performed 100, not
+    // the stale 110.
+    expect(result.decision).toBe("HOLD");
+    expect(result.weight).toBe(100);
+  });
+
+  it("HOLDs at performed weight when set RPE is 'hard' (rir=1) and basis was stale", () => {
+    const lastSession = buildSession({
+      readiness: "normal",
+      exercises: [buildExercise({
+        name: "Barbell Back Squat",
+        sets: [
+          buildSet({ weight: 100, reps: 5, rir: 1 }), // hard / close to limit
+          buildSet({ weight: 100, reps: 5, rir: 1 }),
+          buildSet({ weight: 100, reps: 5, rir: 1 }),
+        ],
+        prescribed: { sets: 3, reps: 5, weight: 100 },
+      })],
+    });
+    const staleLiftState = {
+      currentWeight: 110,
+      currentRepRange: { reps: 5, sets: 3 },
+      bestE1RM: 117,
+      consecutiveHolds: 0,
+      stallSignal: null,
+      history: [],
+    };
+    const reconciled = reconcileLiftStateWithSession(
+      staleLiftState,
+      lastSession.blocks[0].exercises[0],
+    );
+    const result = computeNextPrescription({
+      liftName: "Barbell Back Squat",
+      history: [lastSession],
+      liftState: reconciled,
+      muscleAnchor: null,
+      context: { readiness: "normal", currentWeight: 100 },
+    });
+    expect(result.decision).toBe("HOLD");
+    expect(result.weight).toBe(100); // not 110, not 112.5
+  });
+
+  it("reconcileLiftStateWithSession returns input untouched when nothing performed", () => {
+    const liftState = { currentWeight: 100, history: [] };
+    const ex = buildExercise({ sets: [] });
+    expect(reconcileLiftStateWithSession(liftState, ex)).toBe(liftState);
+  });
+
+  it("reconcileLiftStateWithSession handles null liftState", () => {
+    expect(reconcileLiftStateWithSession(null, buildExercise({}))).toBe(null);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// 10. Starting-weight helpers — BW% multipliers for main lifts (Task 5)
+// ────────────────────────────────────────────────────────────────────────────
+describe("startingWeightForLift — BW% seeded starts", () => {
+  it("computes Back Squat at 0.75 × bodyweight, rounded to 2.5kg", () => {
+    expect(startingWeightForLift("Barbell Back Squat", 80)).toBe(60);   // 60.0
+    expect(startingWeightForLift("Barbell Back Squat", 73)).toBe(55);   // 54.75 → 55
+  });
+
+  it("computes Hex Bar Deadlift at 1.0 × bodyweight", () => {
+    expect(startingWeightForLift("Hex Bar Deadlift", 80)).toBe(80);
+  });
+
+  it("computes Barbell Bench Press at 0.65 × bodyweight", () => {
+    expect(startingWeightForLift("Barbell Bench Press", 80)).toBe(52.5); // 52.0 → 52.5
+  });
+
+  it("computes OHP at 0.40 × bodyweight", () => {
+    expect(startingWeightForLift("Barbell Overhead Press", 80)).toBe(32.5); // 32.0 → 32.5
+  });
+
+  it("computes Power Clean at 0.50 × bodyweight", () => {
+    expect(startingWeightForLift("Power Clean", 80)).toBe(40);
+  });
+
+  it("floors at 20kg (empty bar) for very light users", () => {
+    expect(startingWeightForLift("Barbell Bench Press", 25)).toBe(20); // 16.25 → 20
+    expect(startingWeightForLift("Barbell Overhead Press", 40)).toBe(20); // 16 → 20
+  });
+
+  it("returns null when bodyweight is null/undefined", () => {
+    expect(startingWeightForLift("Barbell Back Squat", null)).toBe(null);
+    expect(startingWeightForLift("Barbell Back Squat", undefined)).toBe(null);
+  });
+
+  it("returns null for non-main lifts (caller falls back to SESSIONS default)", () => {
+    expect(startingWeightForLift("DB Curl", 80)).toBe(null);
+    expect(startingWeightForLift("Lateral Raise", 80)).toBe(null);
+    expect(startingWeightForLift("Chest-Supported DB Row", 80)).toBe(null);
+  });
+
+  it("roundToHalfPlate rounds to nearest 2.5kg", () => {
+    expect(roundToHalfPlate(50)).toBe(50);
+    expect(roundToHalfPlate(51)).toBe(50);
+    // 51.25 is exactly halfway → JS Math.round rounds half-up → 52.5
+    expect(roundToHalfPlate(51.25)).toBe(52.5);
+    expect(roundToHalfPlate(52.5)).toBe(52.5);
+    expect(roundToHalfPlate(53.74)).toBe(52.5);
+    expect(roundToHalfPlate(53.76)).toBe(55);
   });
 });


### PR DESCRIPTION
Task 2 — Standing Calf Raise mismatch: SESSIONS Day A finisher exB and afin-B pool[0] now both at reps:15, weight:35, vid:"3UWi44yN-wM", loadType:"machine". Brought afin-A pool entries into compliance with the loadType field. Added tests/programme.test.js with a pool[0] === SESSIONS-default invariant test.

Task 3 — analytics.js loadType-aware volume: per_db exercises now double for systemic volume across both arms. Applied in weeklyVolume and aggregateVolume; cached set.volume is multiplied at read time so records logged pre-fix still aggregate correctly.

Task 4 — loadType captions in SessionScreen: weight input now carries a small italic caption telling the user what the entered number represents ("weight on the bar", "weight per dumbbell", "total weight", "machine stack weight", "added weight"). Captions table covers both the programme.js and storage.js loadType vocabularies.

Task 5 — BW-percentage starting weights: main lifts (Squat 0.75x, Bench 0.65x, Hex Bar DL 1.0x, OHP 0.40x, Power Clean 0.50x) now seed from the user's captured bodyweight on first session via startingWeightForLift in storage.js. Rounded to 2.5kg, floored at 20kg (empty bar). Falls back to SESSIONS default when bodyweight unset. Wired into getW, pushSetToDraft, and the retro logger's initial entries.

Task 6 — Progression engine bug: topSetWeight was Math.max-blending the actually-performed loads with liftState.currentWeight as a fallback, which let a stale seed (the old hardcoded SESSIONS default, or a prior session's adjusted weight) override what the user just performed — so HOLD prescriptions surfaced at the stale number, not the just-lifted one. Two-part fix: (a) topSetWeight uses actual performed loads only and falls back when empty/all-zero, (b) added reconcileLiftStateWithSession helper called BEFORE computeNextPrescription in both the live and retro finalise paths. Full-path regression test exercises stale liftState + cooked top set through to next prescription.

Task 7a — Retro time window: findRecentDays was using toISOString().slice(0,10) on a Date set to local midnight, which in BST (UTC+1) shifts the date string back a day. UK users checking on Saturday morning saw Thursday/Wednesday/Tuesday in the picker instead of Friday/Thursday/Wednesday. Now uses local date components. Added a BST regression test.

Task 7b — Per-set RPE picker: RpeCard was using the legacy easy/hard/limit scale in the active workout. Standardised on easy/normal/cooked matching the retro logger and the per-day readiness scale. Legacy aliases (hard, limit) remain only inside rpeToRir for v1 record migration.