### PR TITLE
Add .gitignore for Next.js build artefacts and node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# dependencies
+/node_modules
+/.pnp
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# env files
+.env*
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts


### PR DESCRIPTION
The repo lacked a .gitignore so build artefacts (.next/) and dependencies (node_modules/) showed as untracked on every status. Standard Next.js ignores.