### PR TITLE
Migrate analytics muscle bucketing to DISPLAY_BUCKET vocabulary

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -123,32 +123,44 @@ export function weeklyVolume(history) {
     .sort((a, b) => a.weekStart.localeCompare(b.weekStart));
 }
 
-// Collapse granular muscle names into broader groups for rollup readability.
-// Order matters — specific groups (Triceps, Biceps, Core) checked BEFORE
-// more generic ones (Chest, Back, Legs) so compound strings like
-// "Triceps & chest" or "Adductors / Core" bucket correctly.
-// "Full body" is deliberately NOT a group — we reassign those exercises
-// to their dominant mover (e.g. Power Clean → Legs).
+// Bucket raw `ex.muscle` strings into the 9 display groups used by the
+// Performance Lab Weekly Volume chart. Output vocabulary matches
+// DISPLAY_BUCKET in lib/exercise-anatomy.js and the MUSCLE_COLOURS map
+// in lib/tokens.js: Quads / Glutes / Hamstrings / Calves / Chest / Back
+// / Shoulders / Arms / Core, plus "Other" as fallback.
+//
+// Order matters — specific tokens must be checked BEFORE more generic
+// ones. Two ordering subtleties:
+//
+//   1. delt / shoulder / cuff before lat. Otherwise "Lateral delt"
+//      matches "lat" first and gets miscategorised as Back.
+//   2. Among leg groups, quad → glute → ham. Compound labels like
+//      "Quads & Glutes" → Quads (first-mentioned wins). "Glutes / Hams"
+//      → Glutes for the same reason.
+//
+// Posterior chain / full body / explosive (Power Clean, Hex Bar DL):
+// bucketed as Glutes since hip extension is the dominant joint action.
+// Adductors: bucketed as Glutes (closest functional bucket since there
+// is no adductor display group).
+//
+// Mirrored in lib/storage.js _normaliseMuscle — the equivalence test in
+// tests/analytics.test.js asserts both copies stay in lockstep.
 function normaliseMuscle(raw) {
   if (!raw) return null;
   const s = raw.toLowerCase();
-  // Specific groups first
-  if (s.includes("tricep"))                                   return "Triceps";
-  // Lats are a back muscle — check before bicep so "lats / biceps" goes to Back
-  if (s.includes("lat"))                                      return "Back";
-  if (s.includes("bicep") || s.includes("brachial"))          return "Biceps";
-  if (s.includes("core") || s.includes("anti"))               return "Core";
-  // Shoulders before back/chest because "rear delts / cuff" etc. are
-  // unambiguously shoulder-family even if they contain other fragments
+  if (s.includes("tricep"))                                                return "Arms";
   if (s.includes("delt") || s.includes("shoulder") || s.includes("cuff")) return "Shoulders";
-  // Full-body / explosive lifts get reassigned to their dominant mover.
-  // Power Clean, Hex Bar Deadlift etc. are leg-dominant.
-  if (s.includes("full body") || s.includes("explosive") || s.includes("posterior chain")) return "Legs";
-  // Leg family
-  if (s.includes("quad") || s.includes("glute") || s.includes("ham") || s.includes("adductor")) return "Legs";
-  // Chest and back come last so they don't grab compound strings
-  if (s.includes("chest") || s.includes("pec"))               return "Chest";
-  if (s.includes("back"))                                     return "Back";
+  if (s.includes("lat"))                                                   return "Back";
+  if (s.includes("bicep") || s.includes("brachial") || s.includes("forearm")) return "Arms";
+  if (s.includes("core")  || s.includes("anti"))                           return "Core";
+  if (s.includes("calf")  || s.includes("calves"))                         return "Calves";
+  if (s.includes("quad"))                                                  return "Quads";
+  if (s.includes("glute"))                                                 return "Glutes";
+  if (s.includes("ham"))                                                   return "Hamstrings";
+  if (s.includes("posterior") || s.includes("full body") || s.includes("explosive")) return "Glutes";
+  if (s.includes("adductor"))                                              return "Glutes";
+  if (s.includes("chest") || s.includes("pec"))                            return "Chest";
+  if (s.includes("back"))                                                  return "Back";
   return "Other";
 }
 
@@ -437,4 +449,5 @@ export const __test_p4__ = {
   recordsInWindow,
   aggregateVolume,
   recordTime,
+  normaliseMuscle,
 };

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -1037,21 +1037,32 @@ export function finaliseDraft(draft) {
 }
 
 // ─── Muscle normaliser (mirrors analytics.js — duplicated to avoid circular) ──
-// When Phase 1+ extracts this to a shared lib, storage + analytics both import from there.
+// Output vocabulary matches DISPLAY_BUCKET in lib/exercise-anatomy.js and
+// MUSCLE_COLOURS in lib/tokens.js. See analytics.js#normaliseMuscle for the
+// ordering rationale; both copies must stay identical and the equivalence
+// test in tests/analytics.test.js enforces that.
 function _normaliseMuscle(raw) {
   if (!raw) return null;
   const s = raw.toLowerCase();
-  if (s.includes("tricep"))                                   return "Triceps";
-  if (s.includes("lat"))                                      return "Back";
-  if (s.includes("bicep") || s.includes("brachial"))          return "Biceps";
-  if (s.includes("core") || s.includes("anti"))               return "Core";
+  if (s.includes("tricep"))                                                return "Arms";
   if (s.includes("delt") || s.includes("shoulder") || s.includes("cuff")) return "Shoulders";
-  if (s.includes("full body") || s.includes("explosive") || s.includes("posterior chain")) return "Legs";
-  if (s.includes("quad") || s.includes("glute") || s.includes("ham") || s.includes("adductor")) return "Legs";
-  if (s.includes("chest") || s.includes("pec"))               return "Chest";
-  if (s.includes("back"))                                     return "Back";
+  if (s.includes("lat"))                                                   return "Back";
+  if (s.includes("bicep") || s.includes("brachial") || s.includes("forearm")) return "Arms";
+  if (s.includes("core")  || s.includes("anti"))                           return "Core";
+  if (s.includes("calf")  || s.includes("calves"))                         return "Calves";
+  if (s.includes("quad"))                                                  return "Quads";
+  if (s.includes("glute"))                                                 return "Glutes";
+  if (s.includes("ham"))                                                   return "Hamstrings";
+  if (s.includes("posterior") || s.includes("full body") || s.includes("explosive")) return "Glutes";
+  if (s.includes("adductor"))                                              return "Glutes";
+  if (s.includes("chest") || s.includes("pec"))                            return "Chest";
+  if (s.includes("back"))                                                  return "Back";
   return "Other";
 }
+
+// Export for parity tests with analytics.js — confirms the two duplicates
+// stay in lockstep. Not used by runtime code.
+export const __test_storage__ = { _normaliseMuscle };
 
 // ─── v1 → v2 migration (read-time) ────────────────────────────────────────────
 // Takes an old session record, returns a v2-shaped record with derived fields

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -43,10 +43,12 @@ export const T = {
   ease: "cubic-bezier(0.22, 1, 0.36, 1)",
 };
 
-// Muscle group colours for analytics — 9 display buckets matching the
-// DISPLAY_BUCKET map in lib/exercise-anatomy.js. Lower body splits into
-// Quads / Glutes / Hamstrings / Calves (was just "Legs"); upper-arm muscles
-// merge into "Arms" (was Biceps + Triceps separately).
+// Muscle group colours for analytics — 9 display buckets that match what
+// normaliseMuscle in lib/analytics.js emits (and its mirror _normaliseMuscle
+// in lib/storage.js). Lower body splits into Quads / Glutes / Hamstrings /
+// Calves; upper-arm muscles merge into "Arms". The invariant test in
+// tests/analytics.test.js asserts every value the normaliser can return
+// has a key here — drift in this map should be caught by that test.
 //
 // Palette discipline: leg muscles share a warm-earth family with luminance
 // variation for visual stacking. Upper body keeps the original chart accent

--- a/tests/analytics.test.js
+++ b/tests/analytics.test.js
@@ -1,6 +1,6 @@
 // tests/analytics.test.js
 // ────────────────────────────────────────────────────────────────────────────
-// Volume aggregation correctness.
+// Volume aggregation correctness + muscle-bucket vocabulary invariants.
 //
 // Coverage focus:
 //   1. per_db exercises double for volume (DB curl × 10kg × 10 reps both arms
@@ -8,12 +8,23 @@
 //      exercise is under-counted by half in per-muscle distribution charts.
 //   2. Non-per_db loadTypes don't double (1×).
 //   3. Legacy records without loadType default to 1× (don't retro-multiply).
+//   4. normaliseMuscle emits the 9-bucket DISPLAY_BUCKET vocabulary
+//      (Quads/Glutes/Hamstrings/Calves/Chest/Back/Shoulders/Arms/Core + Other).
+//   5. Every value normaliseMuscle can emit has a key in MUSCLE_COLOURS —
+//      the invariant that would have caught the Weekly Volume colour
+//      collision bug.
+//   6. The duplicated normaliser in storage.js stays in lockstep with the
+//      analytics.js copy.
 // ────────────────────────────────────────────────────────────────────────────
 
 import { describe, it, expect } from "vitest";
 import { weeklyVolume, __test_p4__ } from "../lib/analytics.js";
+import { __test_storage__ } from "../lib/storage.js";
+import { DISPLAY_BUCKET } from "../lib/exercise-anatomy.js";
+import { MUSCLE_COLOURS } from "../lib/tokens.js";
 
-const { aggregateVolume } = __test_p4__;
+const { aggregateVolume, normaliseMuscle } = __test_p4__;
+const { _normaliseMuscle } = __test_storage__;
 
 function buildSet({ weight = 10, reps = 10, loadType = null, volume = null, effectiveLoad = null }) {
   return {
@@ -51,19 +62,19 @@ describe("aggregateVolume — per_db loadType doubles", () => {
       }],
     });
     const result = aggregateVolume([session]);
-    // 3 sets × (10kg × 10 reps × 2 hands) = 600
-    expect(result.byMuscle.Biceps).toBe(600);
+    // 3 sets × (10kg × 10 reps × 2 hands) = 600. Biceps now buckets to "Arms".
+    expect(result.byMuscle.Arms).toBe(600);
     expect(result.total).toBe(600);
   });
 
   it("doubles via exercise-level loadType when sets lack loadType (legacy records)", () => {
     // v1 records: per-set loadType absent; rely on exercise-level loadType.
-    // Use a muscle label that doesn't accidentally normalise to Back via the
-    // existing "lat" substring rule (e.g. "Lateral delt" → "Back").
+    // "Lateral delt" used to mis-bucket to Back via the substring rule; the
+    // new ordering (delt before lat) puts it in Shoulders.
     const session = buildSession({
       exercises: [{
         name: "Lateral Raise",
-        muscle: "Shoulders",
+        muscle: "Lateral delt",
         loadType: "per_db",
         sets: [
           buildSet({ weight: 8, reps: 15, loadType: null, volume: 120 }),
@@ -88,7 +99,7 @@ describe("aggregateVolume — per_db loadType doubles", () => {
       }],
     });
     const result = aggregateVolume([session]);
-    expect(result.byMuscle.Legs).toBe(500); // 1×
+    expect(result.byMuscle.Quads).toBe(500); // 1×
   });
 
   it("does NOT double for machine, total, loaded_bw, or bodyweight loadTypes", () => {
@@ -105,7 +116,9 @@ describe("aggregateVolume — per_db loadType doubles", () => {
       ],
     });
     const result = aggregateVolume([session]);
-    expect(result.byMuscle.Legs).toBe(1500); // 1000 + 500
+    // New vocabulary splits this: Quadriceps → Quads, Glutes → Glutes.
+    expect(result.byMuscle.Quads).toBe(1000);
+    expect(result.byMuscle.Glutes).toBe(500);
   });
 
   it("legacy records without any loadType default to 1× (no retro-multiplier)", () => {
@@ -136,7 +149,7 @@ describe("aggregateVolume — per_db loadType doubles", () => {
     });
     const result = aggregateVolume([session]);
     // 10 × 10 × 2 = 200
-    expect(result.byMuscle.Biceps).toBe(200);
+    expect(result.byMuscle.Arms).toBe(200);
   });
 });
 
@@ -158,7 +171,116 @@ describe("weeklyVolume — per_db loadType doubles", () => {
     const weeks = weeklyVolume([session]);
     expect(weeks.length).toBe(1);
     // 3 × 120 × 2 = 720
-    expect(weeks[0].byMuscle.Biceps.volume).toBe(720);
-    expect(weeks[0].byMuscle.Biceps.sets).toBe(3);
+    expect(weeks[0].byMuscle.Arms.volume).toBe(720);
+    expect(weeks[0].byMuscle.Arms.sets).toBe(3);
   });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Muscle-bucket vocabulary — the invariant that would have caught the
+// Weekly Volume colour-collision bug.
+// ────────────────────────────────────────────────────────────────────────────
+describe("MUSCLE_COLOURS invariant — every bucket has a colour", () => {
+  it("every value normaliseMuscle can emit has a key in MUSCLE_COLOURS", () => {
+    // The canonical bucket set = unique values of DISPLAY_BUCKET, plus the
+    // "Other" fallback the normaliser uses for unknown muscles.
+    const expectedBuckets = [...new Set(Object.values(DISPLAY_BUCKET)), "Other"];
+    for (const bucket of expectedBuckets) {
+      expect(MUSCLE_COLOURS[bucket], `MUSCLE_COLOURS missing key "${bucket}"`).toBeTruthy();
+    }
+  });
+
+  it("every MUSCLE_COLOURS value is a unique hex (no visual collisions)", () => {
+    const colours = Object.values(MUSCLE_COLOURS);
+    const unique  = new Set(colours);
+    expect(unique.size).toBe(colours.length);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// normaliseMuscle behaviour — locks in the bucketing rules.
+// ────────────────────────────────────────────────────────────────────────────
+describe("normaliseMuscle — DISPLAY_BUCKET vocabulary", () => {
+  // Fixture covers every raw muscle string shape that appears in programme.js
+  // (and a couple of synthetic edge cases). New-bucket expectations on the right.
+  const cases = [
+    // Leg family — granularity goal of the migration
+    ["Quadriceps",                       "Quads"],
+    ["Quads & Glutes",                   "Quads"],       // first-mentioned wins
+    ["Glutes",                           "Glutes"],
+    ["Glutes / Hams",                    "Glutes"],      // first-mentioned wins
+    ["Hamstrings",                       "Hamstrings"],
+    ["Calves",                           "Calves"],
+    ["Posterior chain",                  "Glutes"],      // hip-extension primary
+    ["Full body / explosive",            "Glutes"],      // Power Clean
+    ["Quads & Glutes / Adductors",       "Quads"],
+    ["Adductors",                        "Glutes"],      // closest functional bucket
+
+    // Upper body
+    ["Chest",                            "Chest"],
+    ["Upper chest",                      "Chest"],
+    ["Chest / medial",                   "Chest"],
+    ["Upper back",                       "Back"],
+    ["Mid back",                         "Back"],
+    ["Lats",                             "Back"],
+    ["Lats / Biceps",                    "Back"],        // lats before bicep
+    ["Lats / biceps",                    "Back"],
+
+    // Shoulders — note "Lateral delt" must NOT mis-bucket to Back
+    ["Shoulders",                        "Shoulders"],
+    ["Lateral delt",                     "Shoulders"],   // delt before lat
+    ["Rear delts / cuff",                "Shoulders"],
+    ["Side delts",                       "Shoulders"],
+    ["Front delts",                      "Shoulders"],
+
+    // Arms (biceps + triceps + forearms merge for chart simplicity)
+    ["Biceps",                           "Arms"],
+    ["Triceps",                          "Arms"],
+    ["Biceps & brachialis",              "Arms"],
+    ["Biceps & forearms",                "Arms"],
+    ["Triceps & chest",                  "Arms"],        // tricep checked first
+    ["Forearms",                         "Arms"],
+
+    // Core
+    ["Core",                             "Core"],
+    ["Core / Anti-rot",                  "Core"],
+    ["Adductors / Core",                 "Core"],        // core check wins
+
+    // Unknown / fallback
+    ["Vibes",                            "Other"],
+    ["",                                 null],
+    [null,                               null],
+    [undefined,                          null],
+  ];
+
+  for (const [input, expected] of cases) {
+    it(`"${input}" → ${JSON.stringify(expected)}`, () => {
+      expect(normaliseMuscle(input)).toBe(expected);
+    });
+  }
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Equivalence — the duplicated _normaliseMuscle in storage.js must emit
+// identical results. Locks the two copies together so they can't drift.
+// ────────────────────────────────────────────────────────────────────────────
+describe("normaliseMuscle ≡ _normaliseMuscle (analytics vs storage)", () => {
+  const fixtures = [
+    "Quadriceps", "Quads & Glutes", "Glutes", "Glutes / Hams", "Hamstrings",
+    "Calves", "Posterior chain", "Full body / explosive",
+    "Quads & Glutes / Adductors", "Adductors",
+    "Chest", "Upper chest", "Chest / medial",
+    "Upper back", "Mid back", "Lats", "Lats / Biceps",
+    "Shoulders", "Lateral delt", "Rear delts / cuff",
+    "Biceps", "Triceps", "Biceps & brachialis", "Biceps & forearms",
+    "Triceps & chest", "Forearms",
+    "Core", "Core / Anti-rot", "Adductors / Core",
+    "Vibes", "", null, undefined,
+  ];
+
+  for (const input of fixtures) {
+    it(`agrees on ${JSON.stringify(input)}`, () => {
+      expect(_normaliseMuscle(input)).toBe(normaliseMuscle(input));
+    });
+  }
 });


### PR DESCRIPTION
Weekly Volume chart was rendering Legs, Biceps, and Triceps in identical fallback grey because the colour map and the aggregator had drifted out of sync: MUSCLE_COLOURS in tokens.js was already migrated to the 9-bucket DISPLAY_BUCKET vocabulary (Quads/Glutes/Hamstrings/ Calves/Chest/Back/Shoulders/Arms/Core) but normaliseMuscle was still emitting the older Legs/Biceps/Triceps buckets, none of which had colour keys.

Migrate normaliseMuscle in lib/analytics.js (and its sibling _normaliseMuscle in lib/storage.js) to emit the new vocabulary. This delivers the finer-grained leg breakdown the user wanted (Quads vs Glutes vs Hamstrings as separate chart segments), so a programme over-emphasising one leg muscle becomes legible. Arms merges Biceps/Triceps/Forearms into one chart segment — coaching norm for chart simplicity.

Ordering subtleties locked in by the behaviour test:
  - delt/shoulder/cuff checked BEFORE lat so "Lateral delt" buckets to Shoulders (was wrongly going to Back via the "lat" substring)
  - quad/glute/ham checked in that order so "Quads & Glutes" → Quads and "Glutes / Hams" → Glutes (first-mentioned wins)
  - posterior chain / full body / explosive → Glutes (hip-extension primary mover for Power Clean, Hex Bar DL)
  - adductor → Glutes (closest functional bucket; no adductor group)

No UI changes needed — PerformanceLab.jsx already looks up by bucket name. weeklyVolume / aggregateVolume re-run normaliseMuscle on every read so historic records reclassify automatically; the cached volumeByMuscle in session records is written but not consumed by any current code path.

Added three test groups in tests/analytics.test.js:
  - Invariant: every value normaliseMuscle can return has a MUSCLE_COLOURS key (would have caught the original bug)
  - Behaviour: 30+ fixture cases lock the bucketing rules
  - Equivalence: same fixtures through both analytics and storage copies must agree (drift prevention while the two stay duplicated)