### PR TITLE
Add lib/volume-audit.js: weekly per-muscle volume vs MEV/MAV/MRV

### DIFF
--- a/lib/volume-audit.js
+++ b/lib/volume-audit.js
@@ -1,0 +1,131 @@
+// lib/volume-audit.js
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure helper: compute the weekly weighted-set volume a programme delivers to
+// each muscle, and flag it against evidence-based volume landmarks (MEV/MAV/MRV).
+//
+// This is the measurement tool behind the programme-rebalance work — it turns
+// "Day C feels redundant with Day B" into "the posterior chain gets N weighted
+// sets/week, which is above MRV." Build candidate programmes, re-audit, compare.
+//
+// Set-counting model (matches lib/analytics.js): every exercise in a block earns
+// that block's `sets` count. A 3-set superset gives exA 3 sets AND exB 3 sets —
+// they're distinct movements performed for 3 rounds each. Sets are then spread
+// across muscles by exercise anatomy (primary 1.0 + weighted secondaries) via
+// distributeAcrossMuscles, so a squat credits quads fully and glutes/hams/etc.
+// partially — the same honest accounting the analytics layer uses.
+//
+// Granular, not display-bucketed: the volume landmarks separate each deltoid
+// head ("Shoulders" target applies per head) and keep Biceps/Triceps distinct,
+// so this audit works at the 13-muscle MUSCLES level — NOT the 9-bucket chart
+// vocabulary (which merges delts → Shoulders and biceps/triceps → Arms).
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { SESSIONS } from "./programme.js";
+import { distributeAcrossMuscles, MUSCLES } from "./exercise-anatomy.js";
+
+// Weekly volume landmarks (weighted sets per week), from the project reference
+// data (Israetel/Nuckols/Helms-derived). The "Shoulders (per head)" row applies
+// independently to Front / Side / Rear delts. Forearms has no landmark (it's a
+// stabiliser we track but don't programme volume for) and is reported untargeted.
+export const VOLUME_TARGETS = {
+  Quads:         { mev: 8,  mav: 18, mrv: 22 },
+  Hamstrings:    { mev: 6,  mav: 12, mrv: 16 },
+  Glutes:        { mev: 4,  mav: 12, mrv: 16 },
+  Chest:         { mev: 8,  mav: 16, mrv: 20 },
+  Back:          { mev: 10, mav: 20, mrv: 25 },
+  "Front Delts": { mev: 6,  mav: 12, mrv: 16 },
+  "Side Delts":  { mev: 6,  mav: 12, mrv: 16 },
+  "Rear Delts":  { mev: 6,  mav: 12, mrv: 16 },
+  Biceps:        { mev: 5,  mav: 14, mrv: 20 },
+  Triceps:       { mev: 6,  mav: 14, mrv: 18 },
+  Calves:        { mev: 6,  mav: 12, mrv: 16 },
+  Core:          { mev: 0,  mav: 16, mrv: 25 },
+};
+
+// Display order for reports — landmark muscles first (in table order), then any
+// tracked-but-untargeted muscle (e.g. Forearms) so nothing silently vanishes.
+export const AUDIT_MUSCLE_ORDER = [
+  ...Object.keys(VOLUME_TARGETS),
+  ...Object.values(MUSCLES).filter((m) => !(m in VOLUME_TARGETS)),
+];
+
+const round1 = (n) => Math.round(n * 10) / 10;
+
+// Pull every (exercise, sets) pair out of a block. Main blocks carry `ex`;
+// supersets/finishers carry `exA` + `exB`. Each earns the block's set count.
+function blockExercises(block) {
+  const sets = block?.sets || 0;
+  const out = [];
+  for (const key of ["ex", "exA", "exB"]) {
+    if (block?.[key]) out.push({ ex: block[key], sets });
+  }
+  return out;
+}
+
+/**
+ * Weekly weighted-set volume per (granular) muscle for a programme.
+ *
+ * @param {Array} [sessions]  Programme sessions (defaults to the live SESSIONS).
+ *                            One pass = one training week (A + B + C).
+ * @returns {Record<string, number>}  muscle → weighted sets/week (1dp).
+ */
+export function computeWeeklyVolume(sessions = SESSIONS) {
+  const totals = {};
+  for (const session of sessions || []) {
+    for (const block of session?.blocks || []) {
+      for (const { ex, sets } of blockExercises(block)) {
+        if (!sets) continue;
+        const contrib = distributeAcrossMuscles(ex.name, sets, ex.muscle);
+        for (const [muscle, value] of Object.entries(contrib)) {
+          totals[muscle] = (totals[muscle] || 0) + value;
+        }
+      }
+    }
+  }
+  for (const m of Object.keys(totals)) totals[m] = round1(totals[m]);
+  return totals;
+}
+
+// Volume-band classification against a single muscle's landmarks.
+//   under_mev — won't drive growth (raise it)
+//   low       — MEV..MAV: productive, room to add
+//   optimal   — MAV..MRV: the target window
+//   over_mrv  — above MRV: junk volume / recovery cost (trim it)
+//   untargeted — no landmark for this muscle
+export function classifyVolume(sets, target) {
+  if (!target) return "untargeted";
+  if (sets < target.mev) return "under_mev";
+  if (sets < target.mav) return "low";
+  if (sets <= target.mrv) return "optimal";
+  return "over_mrv";
+}
+
+/**
+ * Full audit: per-muscle volume + landmark + band, plus a flags list of the
+ * actionable extremes (under MEV / over MRV).
+ *
+ * @param {Array} [sessions]
+ * @param {{ targets?: typeof VOLUME_TARGETS }} [opts]
+ * @returns {{ perMuscle: Record<string,{sets:number,target:object|null,status:string}>,
+ *             flags: Array<{muscle:string,status:string,sets:number,target:object|null}> }}
+ */
+export function auditVolume(sessions = SESSIONS, { targets = VOLUME_TARGETS } = {}) {
+  const volume = computeWeeklyVolume(sessions);
+  const muscles = [
+    ...AUDIT_MUSCLE_ORDER,
+    ...Object.keys(volume).filter((m) => !AUDIT_MUSCLE_ORDER.includes(m)),
+  ];
+
+  const perMuscle = {};
+  for (const muscle of muscles) {
+    const sets = round1(volume[muscle] || 0);
+    const target = targets[muscle] || null;
+    perMuscle[muscle] = { sets, target, status: classifyVolume(sets, target) };
+  }
+
+  const flags = Object.entries(perMuscle)
+    .filter(([, r]) => r.status === "under_mev" || r.status === "over_mrv")
+    .map(([muscle, r]) => ({ muscle, status: r.status, sets: r.sets, target: r.target }));
+
+  return { perMuscle, flags };
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "eslint .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "audit:volume": "node scripts/volume-audit.mjs"
   },
   "dependencies": {
     "@vercel/analytics": "^2.0.1",

--- a/scripts/volume-audit.mjs
+++ b/scripts/volume-audit.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+// scripts/volume-audit.mjs
+// ────────────────────────────────────────────────────────────────────────────
+// Print the weekly weighted-set volume the live programme delivers per muscle,
+// banded against MEV/MAV/MRV. Run: `npm run audit:volume`.
+// ────────────────────────────────────────────────────────────────────────────
+
+import { auditVolume } from "../lib/volume-audit.js";
+
+const BAND_LABEL = {
+  under_mev: "⚠ under MEV",
+  low: "· below MAV",
+  optimal: "✓ optimal",
+  over_mrv: "⚠ over MRV",
+  untargeted: "  (no target)",
+};
+
+const { perMuscle, flags } = auditVolume();
+
+const col = (s, w) => String(s).padEnd(w);
+const num = (s, w) => String(s).padStart(w);
+
+console.log("\nWeekly volume audit — default programme (A + B + C, 3 days/week)\n");
+console.log(
+  col("Muscle", 14) + num("Sets", 6) + "   " +
+  num("MEV", 4) + num("MAV", 5) + num("MRV", 5) + "   Band",
+);
+console.log("─".repeat(58));
+
+for (const [muscle, r] of Object.entries(perMuscle)) {
+  const t = r.target
+    ? num(r.target.mev, 4) + num(r.target.mav, 5) + num(r.target.mrv, 5)
+    : num("-", 4) + num("-", 5) + num("-", 5);
+  console.log(col(muscle, 14) + num(r.sets, 6) + "   " + t + "   " + (BAND_LABEL[r.status] || r.status));
+}
+
+console.log("\nFlags (actionable extremes):");
+if (flags.length === 0) {
+  console.log("  none — every targeted muscle is within MEV..MRV.");
+} else {
+  for (const f of flags) {
+    const dir = f.status === "over_mrv"
+      ? `${f.sets} > MRV ${f.target.mrv}`
+      : `${f.sets} < MEV ${f.target.mev}`;
+    console.log(`  ${BAND_LABEL[f.status].trim()}  ${col(f.muscle, 12)} ${dir}`);
+  }
+}
+console.log("");

--- a/tests/volume-audit.test.js
+++ b/tests/volume-audit.test.js
@@ -1,0 +1,141 @@
+// tests/volume-audit.test.js
+// ────────────────────────────────────────────────────────────────────────────
+// Correctness of the weekly-volume audit helper. Tests exercise the TOOL with
+// synthetic programmes (so they stay green when the real programme is rebalanced)
+// plus one light integration pass over the live SESSIONS, and a lockstep
+// invariant tying VOLUME_TARGETS to the granular MUSCLES vocabulary.
+// ────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect } from "vitest";
+import {
+  computeWeeklyVolume,
+  classifyVolume,
+  auditVolume,
+  VOLUME_TARGETS,
+} from "../lib/volume-audit.js";
+import { MUSCLES } from "../lib/exercise-anatomy.js";
+
+// Names chosen so they resolve to NO anatomy entry and NO movement pattern —
+// distributeAcrossMuscles then falls back to the supplied `muscle`, isolating
+// the set-counting logic from the curated anatomy dataset.
+const synthetic = [
+  {
+    name: "Fixture",
+    blocks: [
+      { id: "m", type: "main", sets: 3, ex: { name: "ZZZ1", muscle: "Quads" } },
+      {
+        id: "s",
+        type: "superset",
+        sets: 2,
+        exA: { name: "ZZZ2", muscle: "Biceps" },
+        exB: { name: "ZZZ3", muscle: "Triceps" },
+      },
+    ],
+  },
+];
+
+describe("computeWeeklyVolume", () => {
+  it("counts a main block's sets once, on its fallback muscle", () => {
+    const v = computeWeeklyVolume([{ blocks: [synthetic[0].blocks[0]] }]);
+    expect(v).toEqual({ Quads: 3 });
+  });
+
+  it("counts BOTH superset exercises at the block's set count", () => {
+    const v = computeWeeklyVolume([{ blocks: [synthetic[0].blocks[1]] }]);
+    expect(v).toEqual({ Biceps: 2, Triceps: 2 });
+  });
+
+  it("aggregates across blocks and sessions", () => {
+    expect(computeWeeklyVolume(synthetic)).toEqual({ Quads: 3, Biceps: 2, Triceps: 2 });
+  });
+
+  it("skips blocks with zero/absent sets", () => {
+    const v = computeWeeklyVolume([
+      { blocks: [{ id: "x", sets: 0, ex: { name: "ZZZ1", muscle: "Quads" } }] },
+    ]);
+    expect(v).toEqual({});
+  });
+
+  it("is empty for an empty/garbage programme", () => {
+    expect(computeWeeklyVolume([])).toEqual({});
+    expect(computeWeeklyVolume([{}])).toEqual({});
+  });
+
+  it("defaults to the live SESSIONS when called with no argument", () => {
+    // `sessions = SESSIONS` default — calling bare audits the real programme.
+    expect(Object.keys(computeWeeklyVolume()).length).toBeGreaterThan(0);
+  });
+});
+
+describe("classifyVolume", () => {
+  const t = { mev: 6, mav: 12, mrv: 16 };
+  it("bands by landmark with inclusive MAV/MRV optimal window", () => {
+    expect(classifyVolume(3, t)).toBe("under_mev");
+    expect(classifyVolume(5.9, t)).toBe("under_mev");
+    expect(classifyVolume(6, t)).toBe("low"); // == MEV is productive, not under
+    expect(classifyVolume(11.9, t)).toBe("low");
+    expect(classifyVolume(12, t)).toBe("optimal"); // == MAV
+    expect(classifyVolume(16, t)).toBe("optimal"); // == MRV
+    expect(classifyVolume(16.1, t)).toBe("over_mrv");
+  });
+  it("returns untargeted when no landmark is given", () => {
+    expect(classifyVolume(10, null)).toBe("untargeted");
+  });
+});
+
+describe("auditVolume", () => {
+  it("flags only the actionable extremes (under MEV / over MRV)", () => {
+    // ZZZ-Calves: 2 sets (under MEV 6); ZZZ-Quads: 30 sets (over MRV 22)
+    const prog = [
+      {
+        blocks: [
+          { id: "a", sets: 2, ex: { name: "ZZZ_C", muscle: "Calves" } },
+          { id: "b", sets: 30, ex: { name: "ZZZ_Q", muscle: "Quads" } },
+          { id: "c", sets: 10, ex: { name: "ZZZ_B", muscle: "Biceps" } }, // low, not flagged
+        ],
+      },
+    ];
+    const { perMuscle, flags } = auditVolume(prog);
+    expect(perMuscle.Calves.status).toBe("under_mev");
+    expect(perMuscle.Quads.status).toBe("over_mrv");
+    expect(perMuscle.Biceps.status).toBe("low");
+    const flagged = flags.map((f) => f.muscle);
+    // under_mev + over_mrv are flagged; the "low" Biceps is not. (Untouched
+    // muscles zero-fill to under_mev too — correct for a real full-week audit.)
+    expect(flagged).toContain("Calves");
+    expect(flagged).toContain("Quads");
+    expect(flagged).not.toContain("Biceps");
+    expect(flags.every((f) => f.status === "under_mev" || f.status === "over_mrv")).toBe(true);
+  });
+
+  it("reports a row for every targeted muscle even at zero volume", () => {
+    const { perMuscle } = auditVolume([]);
+    for (const m of Object.keys(VOLUME_TARGETS)) {
+      expect(perMuscle[m]).toBeDefined();
+      expect(perMuscle[m].sets).toBe(0);
+      // Core has MEV 0, so zero volume is "low", not "under_mev"
+      expect(perMuscle[m].status).toBe(m === "Core" ? "low" : "under_mev");
+    }
+  });
+});
+
+describe("integration — live SESSIONS", () => {
+  it("produces a well-formed audit for the real programme", () => {
+    const { perMuscle, flags } = auditVolume();
+    for (const m of Object.keys(VOLUME_TARGETS)) {
+      expect(typeof perMuscle[m].sets).toBe("number");
+      expect(perMuscle[m].sets).toBeGreaterThanOrEqual(0);
+      expect(typeof perMuscle[m].status).toBe("string");
+    }
+    expect(Array.isArray(flags)).toBe(true);
+  });
+});
+
+describe("invariant — targets stay in lockstep with MUSCLES", () => {
+  it("every VOLUME_TARGETS key is a valid granular muscle", () => {
+    const valid = new Set(Object.values(MUSCLES));
+    for (const m of Object.keys(VOLUME_TARGETS)) {
+      expect(valid.has(m), `${m} is not a MUSCLES value`).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Tier 2 #3. Pure helper that computes the weekly weighted-set volume a programme delivers to each of the 13 granular muscles (via distributeAcrossMuscles) and bands it against evidence-based landmarks (MEV/MAV/MRV). Works at the granular MUSCLES level — not the 9-bucket chart vocabulary — because the targets separate each delt head and keep biceps/triceps distinct.

- computeWeeklyVolume(sessions=SESSIONS) -> muscle -> weighted sets/week
- classifyVolume(sets, target) -> under_mev | low | optimal | over_mrv
- auditVolume(sessions, opts) -> { perMuscle, flags }
- scripts/volume-audit.mjs + `npm run audit:volume` for a printed table
- tests cover set-counting, superset double-credit, band boundaries, flag selection, and a lockstep invariant tying VOLUME_TARGETS to MUSCLES

The measurement foundation for the #4 rebalance work. Tests 177/177, lint clean. No app code imports this yet — analysis tool only.