### PR TITLE
Rotation memory: exclude last 3 blocks (kills A→B→A ping-pong)

### DIFF
--- a/components/ForgeApp.jsx
+++ b/components/ForgeApp.jsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import {
   WEEK, STRENGTH_DAY_SESSIONS, SESSIONS,
-  EXERCISE_POOLS, rotateAccessories, rotationDiff,
+  EXERCISE_POOLS, rotateAccessories, rotationDiff, pushHistoryBlock,
   ROTATION_OPTIONAL, ROTATION_AUTO, ROTATION_FORCED,
   DAY_CONFIG, DAY_NAMES, SWAP_DB, EQ_COLOUR,
   // Retrospective logging helpers (compute past-date programme metadata + missing-day detection)
@@ -1017,16 +1017,18 @@ const sProps={
   const todaySessionIdx = STRENGTH_DAY_SESSIONS[todayIdx] ?? 0;
 
   // Actually rotate. Returns the new block so we can compute the diff.
+  // History carries the last ROTATION_MEMORY_BLOCKS selections per slot, so a
+  // freshly-rotated config avoids not just the immediately-prior pick but a
+  // window of recent ones (kills the A→B→A ping-pong single-block memory had).
   const rotate = (showSummary = false) => {
     const oldConfig = programmeBlock.config;
-    const history = {};
-    Object.entries(oldConfig).forEach(([k,ex])=>{ history[k]=ex.name; });
-    const newConfig = rotateAccessories(history);
+    const updatedHistory = pushHistoryBlock(programmeBlock.history, oldConfig);
+    const newConfig = rotateAccessories(updatedHistory);
     const next = {
       number: programmeBlock.number + 1,
       startDate: new Date().toISOString().slice(0,10),
       config: newConfig,
-      history,
+      history: updatedHistory,
     };
     setProgrammeBlock(next);
     PB.save(next);

--- a/lib/programme.js
+++ b/lib/programme.js
@@ -289,19 +289,38 @@ function zonesCompatible(za, zb) {
   return ZONE_ADJ[za]?.includes(zb) || false;
 }
 
-// Pick new accessories, avoiding last block's choices where possible.
+// Pick new accessories, avoiding recent block selections where possible.
 // Zone constraints are honoured via re-pick up to MAX_RETRIES.
 // If no zone-compatible pair exists after retries, we accept the mismatch
 // and log it — grip/muscle-stimulus variety is more important than geography.
+//
+// `history` shape: { [slotKey]: string[] }  — most-recent first, oldest last.
+// We default to excluding up to ROTATION_MEMORY_BLOCKS prior selections per
+// slot (kills the A→B→A ping-pong that single-block memory created). Accepts
+// legacy single-string entries transparently; they're treated as a 1-element
+// array so users upgrading from the old shape lose nothing on first rotate.
+export const ROTATION_MEMORY_BLOCKS = 3;
+
+function recentNamesFor(historyEntry) {
+  if (Array.isArray(historyEntry)) return historyEntry;
+  if (typeof historyEntry === "string") return [historyEntry];
+  return [];
+}
+
 export function rotateAccessories(history = {}) {
-  const MAX_RETRIES = 3;
   const config = {};
 
-  // First pass: independent pick per slot, excluding last selection
+  // First pass: independent pick per slot, excluding up to N recent selections.
   Object.entries(EXERCISE_POOLS).forEach(([key, { pool }]) => {
-    const lastName = history[key];
-    const available = pool.filter(ex => ex.name !== lastName);
-    const candidates = available.length > 0 ? available : pool;
+    const recent = recentNamesFor(history[key]);
+    const available = pool.filter(ex => !recent.includes(ex.name));
+    // Fallback ladder: if 3-block exclusion empties the pool, relax to just
+    // the immediately-prior pick; if even that empties, accept any.
+    let candidates = available;
+    if (candidates.length === 0 && recent.length > 1) {
+      candidates = pool.filter(ex => ex.name !== recent[0]);
+    }
+    if (candidates.length === 0) candidates = pool;
     config[key] = candidates[Math.floor(Math.random() * candidates.length)];
   });
 
@@ -321,6 +340,20 @@ export function rotateAccessories(history = {}) {
   });
 
   return config;
+}
+
+// Push a freshly-rotated config onto the per-slot exclusion history, capped at
+// ROTATION_MEMORY_BLOCKS. Pure helper — given the previous history (in either
+// legacy string or new array shape) and the config that just became active,
+// returns the new history to persist.
+export function pushHistoryBlock(prevHistory = {}, newConfig = {}) {
+  const next = {};
+  Object.entries(newConfig).forEach(([key, ex]) => {
+    if (!ex?.name) return;
+    const prev = recentNamesFor(prevHistory[key]);
+    next[key] = [ex.name, ...prev.filter(n => n !== ex.name)].slice(0, ROTATION_MEMORY_BLOCKS);
+  });
+  return next;
 }
 
 // Compute what changed between two configs — used for the rotation summary card

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -209,7 +209,9 @@ export const PB = {
     number:    1,
     startDate: new Date().toISOString().slice(0, 10),
     config:    {},   // current rotation; empty = use SESSIONS defaults (pool[0])
-    history:   {},   // previous block's selections for exclusion on next rotate
+    history:   {},   // { [slotKey]: string[] } — recent picks (newest first,
+                     // up to ROTATION_MEMORY_BLOCKS). Legacy single-string
+                     // entries are accepted transparently by rotateAccessories.
   }),
   save: (pb) => LS.set("forge:programmeBlock", pb),
 };

--- a/tests/programme.test.js
+++ b/tests/programme.test.js
@@ -13,7 +13,14 @@
 // ────────────────────────────────────────────────────────────────────────────
 
 import { describe, it, expect } from "vitest";
-import { SESSIONS, EXERCISE_POOLS, findRecentDays } from "../lib/programme.js";
+import {
+  SESSIONS,
+  EXERCISE_POOLS,
+  findRecentDays,
+  rotateAccessories,
+  pushHistoryBlock,
+  ROTATION_MEMORY_BLOCKS,
+} from "../lib/programme.js";
 
 // ─── Pool[0] invariant ──────────────────────────────────────────────────────
 describe("EXERCISE_POOLS pool[0] === SESSIONS default", () => {
@@ -106,5 +113,98 @@ describe("findRecentDays — local timezone handling", () => {
 
   it("daysBack=0 returns empty list", () => {
     expect(findRecentDays([], 0)).toEqual([]);
+  });
+});
+
+// ─── Rotation memory (3-block exclusion) ────────────────────────────────────
+describe("rotation memory — 3-block exclusion", () => {
+  it("ROTATION_MEMORY_BLOCKS is 3 (the spec'd memory depth)", () => {
+    expect(ROTATION_MEMORY_BLOCKS).toBe(3);
+  });
+
+  it("excludes every name in the history array for a slot", () => {
+    // Pick a slot with a pool ≥ 4 so 3-block exclusion can't empty it
+    const slotKey = Object.entries(EXERCISE_POOLS).find(
+      ([, s]) => s.pool.length >= 4,
+    )?.[0];
+    expect(slotKey).toBeTruthy();
+    const pool = EXERCISE_POOLS[slotKey].pool;
+    const excluded = pool.slice(0, 3).map((p) => p.name);
+    const history = { [slotKey]: excluded };
+
+    // 30 trials — every pick must be outside the excluded set
+    for (let i = 0; i < 30; i++) {
+      const cfg = rotateAccessories(history);
+      expect(excluded).not.toContain(cfg[slotKey].name);
+    }
+  });
+
+  it("accepts legacy single-string history entries transparently", () => {
+    const slotKey = Object.keys(EXERCISE_POOLS)[0];
+    const pool = EXERCISE_POOLS[slotKey].pool;
+    const legacy = { [slotKey]: pool[0].name };
+    for (let i = 0; i < 20; i++) {
+      const cfg = rotateAccessories(legacy);
+      expect(cfg[slotKey].name).not.toBe(pool[0].name);
+    }
+  });
+
+  it("falls back to single-block exclusion when 3-block empties the pool", () => {
+    // 2-entry synthetic slot: forcing history of both should still yield a pick
+    // (relaxed fallback excludes only the most-recent name).
+    const slotKey = Object.keys(EXERCISE_POOLS)[0];
+    const pool = EXERCISE_POOLS[slotKey].pool;
+    // history claims EVERY name in the pool is recent → fallback kicks in,
+    // excludes only the most-recent name (recent[0])
+    const allNames = pool.map((p) => p.name);
+    const history = { [slotKey]: allNames };
+    for (let i = 0; i < 20; i++) {
+      const cfg = rotateAccessories(history);
+      expect(cfg[slotKey].name).not.toBe(allNames[0]); // most-recent still avoided
+      expect(allNames.slice(1)).toContain(cfg[slotKey].name);
+    }
+  });
+});
+
+describe("pushHistoryBlock", () => {
+  it("prepends the active config onto history, capped at ROTATION_MEMORY_BLOCKS", () => {
+    const prev = { "ass1-A": ["DB Reverse Lunge", "Reverse Lunge"] };
+    const active = { "ass1-A": { name: "Step-Up" } };
+    const next = pushHistoryBlock(prev, active);
+    expect(next["ass1-A"]).toEqual(["Step-Up", "DB Reverse Lunge", "Reverse Lunge"]);
+  });
+
+  it("evicts the oldest entry when history hits the cap", () => {
+    const prev = { "ass1-A": ["B", "C", "D"] };
+    const active = { "ass1-A": { name: "A" } };
+    const next = pushHistoryBlock(prev, active);
+    expect(next["ass1-A"]).toHaveLength(3);
+    expect(next["ass1-A"]).toEqual(["A", "B", "C"]); // "D" evicted
+  });
+
+  it("dedupes — if the active pick already appears in history, it isn't duplicated", () => {
+    const prev = { "ass1-A": ["A", "B"] };
+    const active = { "ass1-A": { name: "A" } };
+    const next = pushHistoryBlock(prev, active);
+    expect(next["ass1-A"]).toEqual(["A", "B"]); // "A" stays at front, not duplicated
+  });
+
+  it("accepts legacy single-string prev entries", () => {
+    const prev = { "ass1-A": "Reverse Lunge" };
+    const active = { "ass1-A": { name: "Step-Up" } };
+    const next = pushHistoryBlock(prev, active);
+    expect(next["ass1-A"]).toEqual(["Step-Up", "Reverse Lunge"]);
+  });
+
+  it("handles slots absent from prev history (first rotation)", () => {
+    const active = { "ass1-A": { name: "Step-Up" }, "ass1-B": { name: "Cable Row" } };
+    const next = pushHistoryBlock({}, active);
+    expect(next).toEqual({ "ass1-A": ["Step-Up"], "ass1-B": ["Cable Row"] });
+  });
+
+  it("skips slots with no name (defensive)", () => {
+    const active = { "ass1-A": null, "ass1-B": { name: "Cable Row" } };
+    const next = pushHistoryBlock({}, active);
+    expect(next).toEqual({ "ass1-B": ["Cable Row"] });
   });
 });


### PR DESCRIPTION
## Summary

Tier 2 #5 part **1 of 3** — Rotation V2.

Previous behaviour excluded only the immediately-prior block's pick per slot, so a 2-deep pool would oscillate `A→B→A→B` on every rotation. Now the engine tracks the last `ROTATION_MEMORY_BLOCKS` (=3) selections per slot and excludes all of them. No data migration needed — legacy state self-heals on next rotation.

## Changes

**`lib/programme.js`**
- `rotateAccessories(history)` now treats `history[key]` as a string array (most-recent first), excluding every name in it. Legacy single-string entries are accepted transparently.
- Fallback ladder: 3-back exclusion → 1-back exclusion → no exclusion. Guarantees we never repeat the immediately-prior pick unless the pool has only one entry.
- New `pushHistoryBlock(prev, activeConfig)` pure helper: prepends the active config onto history, caps at `ROTATION_MEMORY_BLOCKS`, dedupes.
- Exported new constant `ROTATION_MEMORY_BLOCKS = 3`.

**`components/ForgeApp.jsx`**
- `rotate()` now pushes the about-to-be-replaced config onto `programmeBlock.history` via `pushHistoryBlock` before calling `rotateAccessories`, then persists the new history.

**`lib/storage.js`**
- Updated `PB.get()` comment to describe the new history shape.

**`tests/programme.test.js`** (+10 tests)
- 3-block exclusion holds across 30 random trials.
- Fallback works when the pool is fully excluded.
- Legacy single-string history entries accepted.
- `pushHistoryBlock` caps, dedupes, evicts oldest, accepts legacy prev shape, handles first-rotation and missing-name cases.

## Compatibility

- **No data migration script.** Existing users whose `programmeBlock.history[slot]` is a single string get treated as a 1-element array on first rotation — and the next saved history is in pure-array shape going forward. Zero user-visible behaviour change beyond improved exclusion depth.
- **Rotation diff / summary card unchanged** — surfaces the same "X → Y" change list as before. (The anatomy-aware delta upgrade is PR-3 of this series.)

## Test plan

- [x] `npm test` → 187/187 (incl. existing `pool[0]` and `findRecentDays` invariants).
- [x] `npm run lint` → clean.
- [x] `npx next build` → clean.
- [ ] Manually rotate twice on the preview — verify the second rotation can't pick the same exercise as either of the prior two blocks.

## Part of Rotation V2 series

- **PR-1 (this):** 3-block memory.
- **PR-2 (next):** `loadProfile` tag + slot filter (with new invariant test).
- **PR-3:** Anatomy-aware rotation summary card (per-bucket muscle delta).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gucgxvub2JW5XT1q9dhU8f)_