### PR TITLE
Rotation V2: loadProfile tag + slot filter

### DIFF
--- a/lib/programme.js
+++ b/lib/programme.js
@@ -30,18 +30,18 @@ export const SESSIONS = [
     name:"Strength A", subtitle:"Squat & Push", type:"strength",
     blocks:[
       { id:"a1",  type:"main",      label:"Main lift · 1 of 2", sets:3, rest:180,
-        ex: { name:"Barbell Back Squat",      reps:5,      weight:55,  muscle:"Quadriceps",        vid:"bEv6CCg2BC8", loadType:"barbell" }},
+        ex: { name:"Barbell Back Squat",      reps:5,      weight:55,  muscle:"Quadriceps",        vid:"bEv6CCg2BC8", loadType:"barbell", loadProfile:"heavy_low_rep" }},
       { id:"a2",  type:"main",      label:"Main lift · 2 of 2", sets:3, rest:180,
-        ex: { name:"Barbell Bench Press",     reps:5,      weight:50,  muscle:"Chest",             vid:"ptpmRrzRtWQ", loadType:"barbell" }},
+        ex: { name:"Barbell Bench Press",     reps:5,      weight:50,  muscle:"Chest",             vid:"ptpmRrzRtWQ", loadType:"barbell", loadProfile:"heavy_low_rep" }},
       { id:"ass1",type:"superset",  label:"Superset · 1 of 2",  sets:3, rest:90,
-        exA:{ name:"Barbell Reverse Lunge",   reps:"8/leg",weight:40,  muscle:"Quads & Glutes",    vid:"R-g5yPNYv2k", loadType:"barbell" },
-        exB:{ name:"Chest-Supported DB Row",  reps:10,     weight:22,  muscle:"Upper back",        vid:"vmX58YYK3-8", loadType:"per_db" }},
+        exA:{ name:"Barbell Reverse Lunge",   reps:"8/leg",weight:40,  muscle:"Quads & Glutes",    vid:"R-g5yPNYv2k", loadType:"barbell", loadProfile:"moderate_mid_rep" },
+        exB:{ name:"Chest-Supported DB Row",  reps:10,     weight:22,  muscle:"Upper back",        vid:"vmX58YYK3-8", loadType:"per_db", loadProfile:"moderate_mid_rep" }},
       { id:"ass2",type:"superset",  label:"Superset · 2 of 2",  sets:3, rest:90,
-        exA:{ name:"Barbell Hip Thrust",      reps:10,     weight:65,  muscle:"Glutes",            vid:"xDmFkJxPzeM", loadType:"barbell" },
-        exB:{ name:"Landmine Press",          reps:10,     weight:28,  muscle:"Upper chest",       vid:"gH7PDepHNck", loadType:"barbell" }},
+        exA:{ name:"Barbell Hip Thrust",      reps:10,     weight:65,  muscle:"Glutes",            vid:"xDmFkJxPzeM", loadType:"barbell", loadProfile:"moderate_mid_rep" },
+        exB:{ name:"Landmine Press",          reps:10,     weight:28,  muscle:"Upper chest",       vid:"gH7PDepHNck", loadType:"barbell", loadProfile:"moderate_mid_rep" }},
       { id:"afin",type:"finisher",  label:"Finisher",            sets:3, rest:60,
-        exA:{ name:"Hanging Leg Raise",       reps:10,     weight:null,muscle:"Core",              vid:"Pr1ieGZ5atk", loadType:"bodyweight" },
-        exB:{ name:"Standing Calf Raise",     reps:15,     weight:35,  muscle:"Calves",            vid:"baEXLy09Ncc", loadType:"machine" }},
+        exA:{ name:"Hanging Leg Raise",       reps:10,     weight:null,muscle:"Core",              vid:"Pr1ieGZ5atk", loadType:"bodyweight", loadProfile:"light_high_rep" },
+        exB:{ name:"Standing Calf Raise",     reps:15,     weight:35,  muscle:"Calves",            vid:"baEXLy09Ncc", loadType:"machine", loadProfile:"light_high_rep" }},
     ],
   },
   // ── B · Wednesday · Hinge + Pull ──────────────────────────────────────────
@@ -49,18 +49,18 @@ export const SESSIONS = [
     name:"Strength B", subtitle:"Hinge & Pull", type:"strength",
     blocks:[
       { id:"b1",  type:"main",      label:"Main lift · 1 of 2", sets:3, rest:180,
-        ex: { name:"Hex Bar Deadlift",        reps:5,      weight:75,  muscle:"Posterior chain",   vid:"EsqwERaSTMI", loadType:"barbell" }},
+        ex: { name:"Hex Bar Deadlift",        reps:5,      weight:75,  muscle:"Posterior chain",   vid:"EsqwERaSTMI", loadType:"barbell", loadProfile:"heavy_low_rep" }},
       { id:"b2",  type:"main",      label:"Main lift · 2 of 2", sets:3, rest:180,
-        ex: { name:"Barbell Overhead Press",  reps:5,      weight:30,  muscle:"Shoulders",         vid:"_RlRDWO2jfg", loadType:"barbell" }},
+        ex: { name:"Barbell Overhead Press",  reps:5,      weight:30,  muscle:"Shoulders",         vid:"_RlRDWO2jfg", loadType:"barbell", loadProfile:"heavy_low_rep" }},
       { id:"bss1",type:"superset",  label:"Superset · 1 of 2",  sets:3, rest:90,
-        exA:{ name:"Leg Press",               reps:10,     weight:90,  muscle:"Quads & Glutes",    vid:"nDh_BlnLCGc", loadType:"machine" },
-        exB:{ name:"Pull-Up",                 reps:8,      weight:null,muscle:"Lats",              vid:"Hdc7Mw6BIEE", loadType:"bodyweight" }},
+        exA:{ name:"Leg Press",               reps:10,     weight:90,  muscle:"Quads & Glutes",    vid:"nDh_BlnLCGc", loadType:"machine", loadProfile:"moderate_mid_rep" },
+        exB:{ name:"Pull-Up",                 reps:8,      weight:null,muscle:"Lats",              vid:"Hdc7Mw6BIEE", loadType:"bodyweight", loadProfile:"moderate_mid_rep" }},
       { id:"bss2",type:"superset",  label:"Superset · 2 of 2",  sets:3, rest:90,
-        exA:{ name:"Bulgarian Split Squat",   reps:"8/leg",weight:18,  muscle:"Quads & Glutes",    vid:"uODWo4YqbT8", loadType:"per_db" },
-        exB:{ name:"Machine Hamstring Curl",  reps:12,     weight:35,  muscle:"Hamstrings",        vid:"Lh3iMIcbkBQ", loadType:"machine" }},
+        exA:{ name:"Bulgarian Split Squat",   reps:"8/leg",weight:18,  muscle:"Quads & Glutes",    vid:"uODWo4YqbT8", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+        exB:{ name:"Machine Hamstring Curl",  reps:12,     weight:35,  muscle:"Hamstrings",        vid:"Lh3iMIcbkBQ", loadType:"machine", loadProfile:"moderate_mid_rep" }},
       { id:"bfin",type:"finisher",  label:"Finisher",            sets:2, rest:60,
-        exA:{ name:"Tricep Pushdown",         reps:12,     weight:18,  muscle:"Triceps",           vid:"mRmIthbCSNI", loadType:"total" },
-        exB:{ name:"Lateral Raise",           reps:15,     weight:7,   muscle:"Lateral delt",      vid:"v_ZkxWzYnMc", loadType:"per_db" }},
+        exA:{ name:"Tricep Pushdown",         reps:12,     weight:18,  muscle:"Triceps",           vid:"mRmIthbCSNI", loadType:"total", loadProfile:"light_high_rep" },
+        exB:{ name:"Lateral Raise",           reps:15,     weight:7,   muscle:"Lateral delt",      vid:"v_ZkxWzYnMc", loadType:"per_db", loadProfile:"light_high_rep" }},
     ],
   },
   // ── C · Friday · Power + Volume ───────────────────────────────────────────
@@ -68,19 +68,19 @@ export const SESSIONS = [
     name:"Strength C", subtitle:"Power & Volume", type:"strength",
     blocks:[
       { id:"c1",  type:"main",      label:"Main lift",           sets:3, rest:180,
-        ex: { name:"Power Clean",             reps:5,      weight:40,  muscle:"Full body / explosive", vid:"5vVSGITznQk", loadType:"barbell" }},
+        ex: { name:"Power Clean",             reps:5,      weight:40,  muscle:"Full body / explosive", vid:"5vVSGITznQk", loadType:"barbell", loadProfile:"heavy_low_rep" }},
       { id:"css1",type:"superset",  label:"Superset · 1 of 3",   sets:3, rest:90,
-        exA:{ name:"DB Walking Lunge",        reps:"10/leg",weight:18, muscle:"Quads & Glutes",    vid:"xvC10-eCuXs", loadType:"per_db" },
-        exB:{ name:"Cable Lateral Raise",     reps:15,     weight:7,   muscle:"Lateral delt",      vid:"gsC3pd6lfKY", loadType:"total" }},
+        exA:{ name:"DB Walking Lunge",        reps:"10/leg",weight:18, muscle:"Quads & Glutes",    vid:"xvC10-eCuXs", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+        exB:{ name:"Cable Lateral Raise",     reps:15,     weight:7,   muscle:"Lateral delt",      vid:"gsC3pd6lfKY", loadType:"total", loadProfile:"light_high_rep" }},
       { id:"css2",type:"superset",  label:"Superset · 2 of 3",   sets:4, rest:90,
-        exA:{ name:"Incline DB Press",        reps:10,     weight:26,  muscle:"Upper chest",       vid:"ou6s32mJgjU", loadType:"per_db" },
-        exB:{ name:"Seated Cable Row",        reps:10,     weight:45,  muscle:"Mid back",          vid:"7BkgqzC6WsM", loadType:"total" }},
+        exA:{ name:"Incline DB Press",        reps:10,     weight:26,  muscle:"Upper chest",       vid:"ou6s32mJgjU", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+        exB:{ name:"Seated Cable Row",        reps:10,     weight:45,  muscle:"Mid back",          vid:"7BkgqzC6WsM", loadType:"total", loadProfile:"moderate_mid_rep" }},
       { id:"css3",type:"superset",  label:"Superset · 3 of 3",   sets:3, rest:90,
-        exA:{ name:"DB Curl",                 reps:12,     weight:10,  muscle:"Biceps",            vid:"XE_pHwbst04", loadType:"per_db" },
-        exB:{ name:"Skullcrusher",            reps:12,     weight:18,  muscle:"Triceps",           vid:"OQ4TWXkZjTc", loadType:"barbell" }},
+        exA:{ name:"DB Curl",                 reps:12,     weight:10,  muscle:"Biceps",            vid:"XE_pHwbst04", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+        exB:{ name:"Skullcrusher",            reps:12,     weight:18,  muscle:"Triceps",           vid:"OQ4TWXkZjTc", loadType:"barbell", loadProfile:"moderate_mid_rep" }},
       { id:"cfin",type:"finisher",  label:"Finisher",             sets:3, rest:60,
-        exA:{ name:"Face Pull",               reps:15,     weight:12,  muscle:"Rear delts / cuff", vid:"cuyx9G1bEwg", loadType:"total" },
-        exB:{ name:"Low-to-High Cable Crossover", reps:15, weight:9,   muscle:"Upper pec / medial",vid:"u5X5x1fw_SA", loadType:"total" }},
+        exA:{ name:"Face Pull",               reps:15,     weight:12,  muscle:"Rear delts / cuff", vid:"cuyx9G1bEwg", loadType:"total", loadProfile:"light_high_rep" },
+        exB:{ name:"Low-to-High Cable Crossover", reps:15, weight:9,   muscle:"Upper pec / medial",vid:"u5X5x1fw_SA", loadType:"total", loadProfile:"light_high_rep" }},
     ],
   },
 ];
@@ -103,171 +103,171 @@ export const ZONE_ADJ = {
 
 export const EXERCISE_POOLS = {
   // ── Day A ─────────────────────────────────────────────────────────────────
-  "ass1-A":{ gripDemand:"LOW",  zone:"rack",       pool:[
-    { name:"Barbell Reverse Lunge",  reps:"8/leg", weight:40,  muscle:"Quads & Glutes",  vid:"R-g5yPNYv2k", loadType:"barbell" },
-    { name:"DB Reverse Lunge",       reps:"8/leg", weight:18,  muscle:"Quads & Glutes",  vid:"RZKXLMxPF_I", loadType:"per_db" },
-    { name:"Barbell Step-Up",        reps:"8/leg", weight:35,  muscle:"Quads & Glutes",  vid:"1OS-HTTtqD8", loadType:"barbell" },
-    { name:"Barbell Walking Lunge",  reps:"8/leg", weight:35,  muscle:"Quads & Glutes",  vid:"X9QswJmhBQI", loadType:"barbell" },
-    { name:"Barbell Front Rack Lunge", reps:"8/leg", weight:38, muscle:"Quads & Glutes", vid:"f3WLs_HutLw", loadType:"barbell" },
-    { name:"Deficit Reverse Lunge",  reps:"8/leg", weight:38,  muscle:"Quads & Glutes",  vid:"3PIjhyzF3DI", loadType:"barbell" },
+  "ass1-A":{ gripDemand:"LOW", zone:"rack", loadProfile:"moderate_mid_rep", pool:[
+    { name:"Barbell Reverse Lunge",  reps:"8/leg", weight:40,  muscle:"Quads & Glutes",  vid:"R-g5yPNYv2k", loadType:"barbell", loadProfile:"moderate_mid_rep" },
+    { name:"DB Reverse Lunge",       reps:"8/leg", weight:18,  muscle:"Quads & Glutes",  vid:"RZKXLMxPF_I", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+    { name:"Barbell Step-Up",        reps:"8/leg", weight:35,  muscle:"Quads & Glutes",  vid:"1OS-HTTtqD8", loadType:"barbell", loadProfile:"moderate_mid_rep" },
+    { name:"Barbell Walking Lunge",  reps:"8/leg", weight:35,  muscle:"Quads & Glutes",  vid:"X9QswJmhBQI", loadType:"barbell", loadProfile:"moderate_mid_rep" },
+    { name:"Barbell Front Rack Lunge", reps:"8/leg", weight:38, muscle:"Quads & Glutes", vid:"f3WLs_HutLw", loadType:"barbell", loadProfile:"moderate_mid_rep" },
+    { name:"Deficit Reverse Lunge",  reps:"8/leg", weight:38,  muscle:"Quads & Glutes",  vid:"3PIjhyzF3DI", loadType:"barbell", loadProfile:"moderate_mid_rep" },
   ]},
-  "ass1-B":{ gripDemand:"HIGH", zone:"db",         pool:[
-    { name:"Chest-Supported DB Row", reps:10,      weight:22,  muscle:"Upper back",       vid:"vmX58YYK3-8", loadType:"per_db" },
-    { name:"Single-Arm DB Row",      reps:10,      weight:24,  muscle:"Upper back",       vid:"qN54-QNO1eQ", loadType:"per_db" },
-    { name:"Dumbbell Bent-Over Row", reps:10,      weight:20,  muscle:"Upper back",       vid:"6TSP1TRMUzs", loadType:"per_db" },
-    { name:"TRX Row",                reps:10,      weight:null,muscle:"Upper back",        vid:"fW_jdwZT804", loadType:"bodyweight" },
-    { name:"Meadows Row",            reps:10,      weight:22,  muscle:"Upper back",       vid:"G-jU1aPVhnY", loadType:"per_db" },
-    { name:"Incline DB Row",         reps:10,      weight:20,  muscle:"Upper back",       vid:"2LxN3_3atps", loadType:"per_db" },
-    { name:"Seal Row",               reps:10,      weight:18,  muscle:"Upper back",       vid:"fBgDGkfT8Rc", loadType:"per_db" },
+  "ass1-B":{ gripDemand:"HIGH", zone:"db", loadProfile:"moderate_mid_rep", pool:[
+    { name:"Chest-Supported DB Row", reps:10,      weight:22,  muscle:"Upper back",       vid:"vmX58YYK3-8", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+    { name:"Single-Arm DB Row",      reps:10,      weight:24,  muscle:"Upper back",       vid:"qN54-QNO1eQ", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+    { name:"Dumbbell Bent-Over Row", reps:10,      weight:20,  muscle:"Upper back",       vid:"6TSP1TRMUzs", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+    { name:"TRX Row",                reps:10,      weight:null,muscle:"Upper back",        vid:"fW_jdwZT804", loadType:"bodyweight", loadProfile:"moderate_mid_rep" },
+    { name:"Meadows Row",            reps:10,      weight:22,  muscle:"Upper back",       vid:"G-jU1aPVhnY", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+    { name:"Incline DB Row",         reps:10,      weight:20,  muscle:"Upper back",       vid:"2LxN3_3atps", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+    { name:"Seal Row",               reps:10,      weight:18,  muscle:"Upper back",       vid:"fBgDGkfT8Rc", loadType:"per_db", loadProfile:"moderate_mid_rep" },
   ]},
-  "ass2-A":{ gripDemand:"NONE", zone:"rack",       pool:[
-    { name:"Barbell Hip Thrust",     reps:10,      weight:65,  muscle:"Glutes",           vid:"xDmFkJxPzeM", loadType:"barbell" },
-    { name:"Single-Leg Hip Thrust",  reps:10,      weight:45,  muscle:"Glutes",           vid:"4ilXaDauMnE", loadType:"barbell" },
-    { name:"Banded Hip Thrust",      reps:15,      weight:null,muscle:"Glutes",            vid:"1hZv0N2szAE", loadType:"bodyweight" },
-    { name:"Barbell Glute Bridge",   reps:12,      weight:55,  muscle:"Glutes",           vid:"0od5lwWMGV8", loadType:"barbell" },
-    { name:"B-Stance Hip Thrust",    reps:10,      weight:55,  muscle:"Glutes",           vid:"7M9-tWMk3-w", loadType:"barbell" },
-    { name:"Frog Pump",              reps:20,      weight:null,muscle:"Glutes",            vid:"HyCiZVMMDW4", loadType:"bodyweight" },
+  "ass2-A":{ gripDemand:"NONE", zone:"rack", loadProfile:"moderate_mid_rep", pool:[
+    { name:"Barbell Hip Thrust",     reps:10,      weight:65,  muscle:"Glutes",           vid:"xDmFkJxPzeM", loadType:"barbell", loadProfile:"moderate_mid_rep" },
+    { name:"Single-Leg Hip Thrust",  reps:10,      weight:45,  muscle:"Glutes",           vid:"4ilXaDauMnE", loadType:"barbell", loadProfile:"moderate_mid_rep" },
+    { name:"Banded Hip Thrust",      reps:15,      weight:null,muscle:"Glutes",            vid:"1hZv0N2szAE", loadType:"bodyweight", loadProfile:"moderate_mid_rep" },
+    { name:"Barbell Glute Bridge",   reps:12,      weight:55,  muscle:"Glutes",           vid:"0od5lwWMGV8", loadType:"barbell", loadProfile:"moderate_mid_rep" },
+    { name:"B-Stance Hip Thrust",    reps:10,      weight:55,  muscle:"Glutes",           vid:"7M9-tWMk3-w", loadType:"barbell", loadProfile:"moderate_mid_rep" },
+    { name:"Frog Pump",              reps:20,      weight:null,muscle:"Glutes",            vid:"HyCiZVMMDW4", loadType:"bodyweight", loadProfile:"moderate_mid_rep" },
   ]},
-  "ass2-B":{ gripDemand:"MED",  zone:"rack",       pool:[
-    { name:"Landmine Press",               reps:10, weight:28,  muscle:"Upper chest",     vid:"gH7PDepHNck", loadType:"barbell" },
-    { name:"Single-Arm Landmine Press",    reps:10, weight:22,  muscle:"Upper chest",     vid:"Sjb5meztfSE", loadType:"barbell" },
-    { name:"Incline Landmine Press",       reps:10, weight:22,  muscle:"Upper chest",     vid:"N9_1DnqUAQw", loadType:"barbell" },
-    { name:"Landmine Squeeze Press", reps:12,      weight:22,  muscle:"Upper chest",      vid:"1G-_FTEkoNw", loadType:"barbell" },
-    { name:"Kneeling Landmine Press", reps:10,     weight:22,  muscle:"Upper chest",      vid:"39lH32_Ukos", loadType:"barbell" },
-    { name:"Floor Press",            reps:10,      weight:45,  muscle:"Upper chest",      vid:"L1BKVBQNc9g", loadType:"barbell" },
+  "ass2-B":{ gripDemand:"MED", zone:"rack", loadProfile:"moderate_mid_rep", pool:[
+    { name:"Landmine Press",               reps:10, weight:28,  muscle:"Upper chest",     vid:"gH7PDepHNck", loadType:"barbell", loadProfile:"moderate_mid_rep" },
+    { name:"Single-Arm Landmine Press",    reps:10, weight:22,  muscle:"Upper chest",     vid:"Sjb5meztfSE", loadType:"barbell", loadProfile:"moderate_mid_rep" },
+    { name:"Incline Landmine Press",       reps:10, weight:22,  muscle:"Upper chest",     vid:"N9_1DnqUAQw", loadType:"barbell", loadProfile:"moderate_mid_rep" },
+    { name:"Landmine Squeeze Press", reps:12,      weight:22,  muscle:"Upper chest",      vid:"1G-_FTEkoNw", loadType:"barbell", loadProfile:"moderate_mid_rep" },
+    { name:"Kneeling Landmine Press", reps:10,     weight:22,  muscle:"Upper chest",      vid:"39lH32_Ukos", loadType:"barbell", loadProfile:"moderate_mid_rep" },
+    { name:"Floor Press",            reps:10,      weight:45,  muscle:"Upper chest",      vid:"L1BKVBQNc9g", loadType:"barbell", loadProfile:"moderate_mid_rep" },
   ]},
-  "afin-A":{ gripDemand:"HIGH", zone:"bodyweight", pool:[
-    { name:"Hanging Leg Raise",      reps:10,      weight:null,muscle:"Core",              vid:"Pr1ieGZ5atk", loadType:"bodyweight" },
-    { name:"Toes-to-Bar",            reps:8,       weight:null,muscle:"Core",              vid:null, loadType:"bodyweight" },
-    { name:"Captain's Chair Raise",  reps:12,      weight:null,muscle:"Core",              vid:null, loadType:"bodyweight" },
-    { name:"Hanging Knee Raise",     reps:12,      weight:null,muscle:"Core",              vid:null, loadType:"bodyweight" },
-    { name:"L-Sit Hold",             reps:"20s",   weight:null,muscle:"Core",              vid:null, loadType:"bodyweight" },
-    { name:"Windshield Wiper",       reps:8,       weight:null,muscle:"Core",              vid:null, loadType:"bodyweight" },
+  "afin-A":{ gripDemand:"HIGH", zone:"bodyweight", loadProfile:"light_high_rep", pool:[
+    { name:"Hanging Leg Raise",      reps:10,      weight:null,muscle:"Core",              vid:"Pr1ieGZ5atk", loadType:"bodyweight", loadProfile:"light_high_rep" },
+    { name:"Toes-to-Bar",            reps:8,       weight:null,muscle:"Core",              vid:null, loadType:"bodyweight", loadProfile:"light_high_rep" },
+    { name:"Captain's Chair Raise",  reps:12,      weight:null,muscle:"Core",              vid:null, loadType:"bodyweight", loadProfile:"light_high_rep" },
+    { name:"Hanging Knee Raise",     reps:12,      weight:null,muscle:"Core",              vid:null, loadType:"bodyweight", loadProfile:"light_high_rep" },
+    { name:"L-Sit Hold",             reps:"20s",   weight:null,muscle:"Core",              vid:null, loadType:"bodyweight", loadProfile:"light_high_rep" },
+    { name:"Windshield Wiper",       reps:8,       weight:null,muscle:"Core",              vid:null, loadType:"bodyweight", loadProfile:"light_high_rep" },
   ]},
-  "afin-B":{ gripDemand:"NONE", zone:"machine", pool:[
-    { name:"Standing Calf Raise",    reps:15,      weight:35,  muscle:"Calves",            vid:"baEXLy09Ncc", loadType:"machine" },
-    { name:"Seated Calf Raise",      reps:15,      weight:35,  muscle:"Calves",            vid:"6O5hh1rBtx8", loadType:"machine" },
-    { name:"Smith Calf Raise",       reps:15,      weight:40,  muscle:"Calves",            vid:"wlqTemUXPXY", loadType:"machine" },
-    { name:"Single-Leg Calf Raise",  reps:"15/leg",weight:null,muscle:"Calves",            vid:"ORT4oJ_R8Qs", loadType:"bodyweight" },
-    { name:"Donkey Calf Raise",      reps:15,      weight:40,  muscle:"Calves",            vid:"Jk_fDd57e98", loadType:"machine" },
-    { name:"Leg Press Calf Raise",   reps:15,      weight:55,  muscle:"Calves",            vid:"PYZY00hI43w", loadType:"machine" },
+  "afin-B":{ gripDemand:"NONE", zone:"machine", loadProfile:"light_high_rep", pool:[
+    { name:"Standing Calf Raise",    reps:15,      weight:35,  muscle:"Calves",            vid:"baEXLy09Ncc", loadType:"machine", loadProfile:"light_high_rep" },
+    { name:"Seated Calf Raise",      reps:15,      weight:35,  muscle:"Calves",            vid:"6O5hh1rBtx8", loadType:"machine", loadProfile:"light_high_rep" },
+    { name:"Smith Calf Raise",       reps:15,      weight:40,  muscle:"Calves",            vid:"wlqTemUXPXY", loadType:"machine", loadProfile:"light_high_rep" },
+    { name:"Single-Leg Calf Raise",  reps:"15/leg",weight:null,muscle:"Calves",            vid:"ORT4oJ_R8Qs", loadType:"bodyweight", loadProfile:"light_high_rep" },
+    { name:"Donkey Calf Raise",      reps:15,      weight:40,  muscle:"Calves",            vid:"Jk_fDd57e98", loadType:"machine", loadProfile:"light_high_rep" },
+    { name:"Leg Press Calf Raise",   reps:15,      weight:55,  muscle:"Calves",            vid:"PYZY00hI43w", loadType:"machine", loadProfile:"light_high_rep" },
   ]},
 
   // ── Day B ─────────────────────────────────────────────────────────────────
-  "bss1-A":{ gripDemand:"NONE", zone:"machine",    pool:[
-    { name:"Leg Press",              reps:10,      weight:90,  muscle:"Quads & Glutes",   vid:"nDh_BlnLCGc", loadType:"machine" },
-    { name:"Hack Squat",             reps:10,      weight:55,  muscle:"Quadriceps",       vid:"hrciyIRwFzs", loadType:"machine" },
-    { name:"Leg Extension",          reps:12,      weight:45,  muscle:"Quadriceps",       vid:"ljO4jkwv8wQ", loadType:"machine" },
-    { name:"Pendulum Squat",         reps:10,      weight:50,  muscle:"Quadriceps",       vid:"QCLWnLNM35U", loadType:"machine" },
-    { name:"V-Squat",                reps:10,      weight:55,  muscle:"Quads & Glutes",   vid:"u_GSjH58s0g", loadType:"machine" },
-    { name:"Belt Squat",             reps:10,      weight:50,  muscle:"Quads & Glutes",   vid:"V0bPCIjJA7U", loadType:"machine" },
+  "bss1-A":{ gripDemand:"NONE", zone:"machine", loadProfile:"moderate_mid_rep", pool:[
+    { name:"Leg Press",              reps:10,      weight:90,  muscle:"Quads & Glutes",   vid:"nDh_BlnLCGc", loadType:"machine", loadProfile:"moderate_mid_rep" },
+    { name:"Hack Squat",             reps:10,      weight:55,  muscle:"Quadriceps",       vid:"hrciyIRwFzs", loadType:"machine", loadProfile:"moderate_mid_rep" },
+    { name:"Leg Extension",          reps:12,      weight:45,  muscle:"Quadriceps",       vid:"ljO4jkwv8wQ", loadType:"machine", loadProfile:"moderate_mid_rep" },
+    { name:"Pendulum Squat",         reps:10,      weight:50,  muscle:"Quadriceps",       vid:"QCLWnLNM35U", loadType:"machine", loadProfile:"moderate_mid_rep" },
+    { name:"V-Squat",                reps:10,      weight:55,  muscle:"Quads & Glutes",   vid:"u_GSjH58s0g", loadType:"machine", loadProfile:"moderate_mid_rep" },
+    { name:"Belt Squat",             reps:10,      weight:50,  muscle:"Quads & Glutes",   vid:"V0bPCIjJA7U", loadType:"machine", loadProfile:"moderate_mid_rep" },
   ]},
-  "bss1-B":{ gripDemand:"HIGH", zone:"bodyweight", pool:[
-    { name:"Pull-Up",                reps:8,       weight:null,muscle:"Lats",              vid:"Hdc7Mw6BIEE", loadType:"bodyweight" },
-    { name:"Weighted Pull-Up",       reps:6,       weight:8,   muscle:"Lats",             vid:"Qh0jSDYu2Os", loadType:"loaded_bw" },
-    { name:"Neutral-Grip Pull-Up",   reps:8,       weight:null,muscle:"Lats / Biceps",    vid:"Ai4S1uzMP7A", loadType:"bodyweight" },
-    { name:"Lat Pulldown",           reps:10,      weight:45,  muscle:"Lats",             vid:"hnSqbBk15tw", loadType:"total" },
-    { name:"Chin-Up",                reps:8,       weight:null,muscle:"Lats / Biceps",    vid:"e1YSApl-QcM", loadType:"bodyweight" },
-    { name:"Wide-Grip Pull-Up",      reps:8,       weight:null,muscle:"Lats",             vid:"bHC16skSN6Q", loadType:"bodyweight" },
-    { name:"Assisted Pull-Up",       reps:10,      weight:null,muscle:"Lats",             vid:"gx0RWT7WbmA", loadType:"bodyweight" },
+  "bss1-B":{ gripDemand:"HIGH", zone:"bodyweight", loadProfile:"moderate_mid_rep", pool:[
+    { name:"Pull-Up",                reps:8,       weight:null,muscle:"Lats",              vid:"Hdc7Mw6BIEE", loadType:"bodyweight", loadProfile:"moderate_mid_rep" },
+    { name:"Weighted Pull-Up",       reps:6,       weight:8,   muscle:"Lats",             vid:"Qh0jSDYu2Os", loadType:"loaded_bw", loadProfile:"moderate_mid_rep" },
+    { name:"Neutral-Grip Pull-Up",   reps:8,       weight:null,muscle:"Lats / Biceps",    vid:"Ai4S1uzMP7A", loadType:"bodyweight", loadProfile:"moderate_mid_rep" },
+    { name:"Lat Pulldown",           reps:10,      weight:45,  muscle:"Lats",             vid:"hnSqbBk15tw", loadType:"total", loadProfile:"moderate_mid_rep" },
+    { name:"Chin-Up",                reps:8,       weight:null,muscle:"Lats / Biceps",    vid:"e1YSApl-QcM", loadType:"bodyweight", loadProfile:"moderate_mid_rep" },
+    { name:"Wide-Grip Pull-Up",      reps:8,       weight:null,muscle:"Lats",             vid:"bHC16skSN6Q", loadType:"bodyweight", loadProfile:"moderate_mid_rep" },
+    { name:"Assisted Pull-Up",       reps:10,      weight:null,muscle:"Lats",             vid:"gx0RWT7WbmA", loadType:"bodyweight", loadProfile:"moderate_mid_rep" },
   ]},
-  "bss2-A":{ gripDemand:"LOW",  zone:"db",         pool:[
-    { name:"Bulgarian Split Squat",  reps:"8/leg", weight:18,  muscle:"Quads & Glutes",   vid:"uODWo4YqbT8", loadType:"per_db" },
-    { name:"DB Step-Up",             reps:"8/leg", weight:16,  muscle:"Quads & Glutes",   vid:"aKj-6hgiViA", loadType:"per_db" },
-    { name:"Goblet Squat",           reps:10,      weight:28,  muscle:"Quads & Glutes",   vid:"9W5KAqHfDe8", loadType:"per_db" },
-    { name:"DB Sumo Squat",          reps:10,      weight:30,  muscle:"Quads & Glutes / Adductors", vid:"7BqURseCGSU", loadType:"per_db" },
-    { name:"DB Front Squat",         reps:10,      weight:22,  muscle:"Quads & Glutes",   vid:"B86Zj72LwzA", loadType:"per_db" },
-    { name:"DB Split Squat",         reps:"8/leg", weight:16,  muscle:"Quads & Glutes",   vid:"SGHnCftrZkA", loadType:"per_db" },
+  "bss2-A":{ gripDemand:"LOW", zone:"db", loadProfile:"moderate_mid_rep", pool:[
+    { name:"Bulgarian Split Squat",  reps:"8/leg", weight:18,  muscle:"Quads & Glutes",   vid:"uODWo4YqbT8", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+    { name:"DB Step-Up",             reps:"8/leg", weight:16,  muscle:"Quads & Glutes",   vid:"aKj-6hgiViA", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+    { name:"Goblet Squat",           reps:10,      weight:28,  muscle:"Quads & Glutes",   vid:"9W5KAqHfDe8", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+    { name:"DB Sumo Squat",          reps:10,      weight:30,  muscle:"Quads & Glutes / Adductors", vid:"7BqURseCGSU", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+    { name:"DB Front Squat",         reps:10,      weight:22,  muscle:"Quads & Glutes",   vid:"B86Zj72LwzA", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+    { name:"DB Split Squat",         reps:"8/leg", weight:16,  muscle:"Quads & Glutes",   vid:"SGHnCftrZkA", loadType:"per_db", loadProfile:"moderate_mid_rep" },
   ]},
-  "bss2-B":{ gripDemand:"NONE", zone:"machine",    pool:[
-    { name:"Machine Hamstring Curl", reps:12,      weight:35,  muscle:"Hamstrings",       vid:"Lh3iMIcbkBQ", loadType:"machine" },
-    { name:"Swiss Ball Leg Curl",    reps:12,      weight:null,muscle:"Hamstrings",        vid:"WNB90xXLEOg", loadType:"bodyweight" },
-    { name:"Nordic Curl",            reps:8,       weight:null,muscle:"Hamstrings",        vid:"6NCN6kOagfY", loadType:"bodyweight" },
-    { name:"Seated Leg Curl",        reps:12,      weight:35,  muscle:"Hamstrings",       vid:"NxPR7G_YNHI", loadType:"machine" },
-    { name:"Slider Leg Curl",        reps:10,      weight:null,muscle:"Hamstrings",        vid:"lLUniqm00KM", loadType:"bodyweight" },
-    { name:"Single-Leg Curl",        reps:10,      weight:22,  muscle:"Hamstrings",       vid:"Y1dQUd6OKHk", loadType:"per_db" },
+  "bss2-B":{ gripDemand:"NONE", zone:"machine", loadProfile:"moderate_mid_rep", pool:[
+    { name:"Machine Hamstring Curl", reps:12,      weight:35,  muscle:"Hamstrings",       vid:"Lh3iMIcbkBQ", loadType:"machine", loadProfile:"moderate_mid_rep" },
+    { name:"Swiss Ball Leg Curl",    reps:12,      weight:null,muscle:"Hamstrings",        vid:"WNB90xXLEOg", loadType:"bodyweight", loadProfile:"moderate_mid_rep" },
+    { name:"Nordic Curl",            reps:8,       weight:null,muscle:"Hamstrings",        vid:"6NCN6kOagfY", loadType:"bodyweight", loadProfile:"moderate_mid_rep" },
+    { name:"Seated Leg Curl",        reps:12,      weight:35,  muscle:"Hamstrings",       vid:"NxPR7G_YNHI", loadType:"machine", loadProfile:"moderate_mid_rep" },
+    { name:"Slider Leg Curl",        reps:10,      weight:null,muscle:"Hamstrings",        vid:"lLUniqm00KM", loadType:"bodyweight", loadProfile:"moderate_mid_rep" },
+    { name:"Single-Leg Curl",        reps:10,      weight:22,  muscle:"Hamstrings",       vid:"Y1dQUd6OKHk", loadType:"per_db", loadProfile:"moderate_mid_rep" },
   ]},
-  "bfin-A":{ gripDemand:"LOW",  zone:"cable", pool:[
-    { name:"Tricep Pushdown",        reps:12,      weight:18,  muscle:"Triceps",           vid:"mRmIthbCSNI", loadType:"total" },
-    { name:"Rope Tricep Pushdown",   reps:12,      weight:16,  muscle:"Triceps",           vid:"n2FSCB4vRSA", loadType:"total" },
-    { name:"Cable Overhead Extension",reps:12,     weight:16,  muscle:"Triceps",           vid:"GzmlxvSFE7A", loadType:"total" },
-    { name:"Single-Arm Pushdown",    reps:12,      weight:10,  muscle:"Triceps",           vid:"VAHZcPAUwdQ", loadType:"total" },
-    { name:"Reverse-Grip Pushdown",  reps:12,      weight:14,  muscle:"Triceps",           vid:"8IK6BkC0lWE", loadType:"total" },
-    { name:"DB Overhead Extension",  reps:12,      weight:12,  muscle:"Triceps",           vid:"fYqswDVbJDg", loadType:"per_db" },
+  "bfin-A":{ gripDemand:"LOW", zone:"cable", loadProfile:"light_high_rep", pool:[
+    { name:"Tricep Pushdown",        reps:12,      weight:18,  muscle:"Triceps",           vid:"mRmIthbCSNI", loadType:"total", loadProfile:"light_high_rep" },
+    { name:"Rope Tricep Pushdown",   reps:12,      weight:16,  muscle:"Triceps",           vid:"n2FSCB4vRSA", loadType:"total", loadProfile:"light_high_rep" },
+    { name:"Cable Overhead Extension",reps:12,     weight:16,  muscle:"Triceps",           vid:"GzmlxvSFE7A", loadType:"total", loadProfile:"light_high_rep" },
+    { name:"Single-Arm Pushdown",    reps:12,      weight:10,  muscle:"Triceps",           vid:"VAHZcPAUwdQ", loadType:"total", loadProfile:"light_high_rep" },
+    { name:"Reverse-Grip Pushdown",  reps:12,      weight:14,  muscle:"Triceps",           vid:"8IK6BkC0lWE", loadType:"total", loadProfile:"light_high_rep" },
+    { name:"DB Overhead Extension",  reps:12,      weight:12,  muscle:"Triceps",           vid:"fYqswDVbJDg", loadType:"per_db", loadProfile:"light_high_rep" },
   ]},
-  "bfin-B":{ gripDemand:"LOW",  zone:"db",         pool:[
-    { name:"Lateral Raise",          reps:15,      weight:7,   muscle:"Lateral delt",     vid:"v_ZkxWzYnMc", loadType:"per_db" },
-    { name:"Cable Lateral Raise",    reps:15,      weight:7,   muscle:"Lateral delt",     vid:"gsC3pd6lfKY", loadType:"total" },
-    { name:"Seated Lateral Raise",   reps:15,      weight:6,   muscle:"Lateral delt",     vid:"zt2NMQNJnMs", loadType:"per_db" },
-    { name:"Leaning Lateral Raise",  reps:12,      weight:7,   muscle:"Lateral delt",     vid:"qWif_7SOYpQ", loadType:"per_db" },
-    { name:"DB Lu Raise",            reps:10,      weight:5,   muscle:"Lateral delt",     vid:"Dnb1Dt1yXhs", loadType:"per_db" },
-    { name:"Band Lateral Raise",     reps:15,      weight:null,muscle:"Lateral delt",     vid:"yfNg5sFndbw", loadType:"bodyweight" },
+  "bfin-B":{ gripDemand:"LOW", zone:"db", loadProfile:"light_high_rep", pool:[
+    { name:"Lateral Raise",          reps:15,      weight:7,   muscle:"Lateral delt",     vid:"v_ZkxWzYnMc", loadType:"per_db", loadProfile:"light_high_rep" },
+    { name:"Cable Lateral Raise",    reps:15,      weight:7,   muscle:"Lateral delt",     vid:"gsC3pd6lfKY", loadType:"total", loadProfile:"light_high_rep" },
+    { name:"Seated Lateral Raise",   reps:15,      weight:6,   muscle:"Lateral delt",     vid:"zt2NMQNJnMs", loadType:"per_db", loadProfile:"light_high_rep" },
+    { name:"Leaning Lateral Raise",  reps:12,      weight:7,   muscle:"Lateral delt",     vid:"qWif_7SOYpQ", loadType:"per_db", loadProfile:"light_high_rep" },
+    { name:"DB Lu Raise",            reps:10,      weight:5,   muscle:"Lateral delt",     vid:"Dnb1Dt1yXhs", loadType:"per_db", loadProfile:"light_high_rep" },
+    { name:"Band Lateral Raise",     reps:15,      weight:null,muscle:"Lateral delt",     vid:"yfNg5sFndbw", loadType:"bodyweight", loadProfile:"light_high_rep" },
   ]},
 
   // ── Day C ─────────────────────────────────────────────────────────────────
-  "css1-A":{ gripDemand:"MED",  zone:"db",         pool:[
-    { name:"DB Walking Lunge",       reps:"10/leg",weight:18,  muscle:"Quads & Glutes",   vid:"xvC10-eCuXs", loadType:"per_db" },
-    { name:"DB Reverse Lunge",       reps:"10/leg",weight:18,  muscle:"Quads & Glutes",   vid:"RZKXLMxPF_I", loadType:"per_db" },
-    { name:"DB Step-Up",             reps:"10/leg",weight:16,  muscle:"Quads & Glutes",   vid:"aKj-6hgiViA", loadType:"per_db" },
-    { name:"Bulgarian Split Squat",  reps:"8/leg", weight:18,  muscle:"Quads & Glutes",  vid:"uODWo4YqbT8", loadType:"per_db" },
-    { name:"DB Lateral Lunge",       reps:"8/leg", weight:14,  muscle:"Quads & Glutes",   vid:"4m9R6PijpWI", loadType:"per_db" },
-    { name:"Curtsy Lunge",           reps:"8/leg", weight:12,  muscle:"Quads & Glutes",   vid:"xr9GQeo6lPY", loadType:"per_db" },
+  "css1-A":{ gripDemand:"MED", zone:"db", loadProfile:"moderate_mid_rep", pool:[
+    { name:"DB Walking Lunge",       reps:"10/leg",weight:18,  muscle:"Quads & Glutes",   vid:"xvC10-eCuXs", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+    { name:"DB Reverse Lunge",       reps:"10/leg",weight:18,  muscle:"Quads & Glutes",   vid:"RZKXLMxPF_I", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+    { name:"DB Step-Up",             reps:"10/leg",weight:16,  muscle:"Quads & Glutes",   vid:"aKj-6hgiViA", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+    { name:"Bulgarian Split Squat",  reps:"8/leg", weight:18,  muscle:"Quads & Glutes",  vid:"uODWo4YqbT8", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+    { name:"DB Lateral Lunge",       reps:"8/leg", weight:14,  muscle:"Quads & Glutes",   vid:"4m9R6PijpWI", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+    { name:"Curtsy Lunge",           reps:"8/leg", weight:12,  muscle:"Quads & Glutes",   vid:"xr9GQeo6lPY", loadType:"per_db", loadProfile:"moderate_mid_rep" },
   ]},
-  "css1-B":{ gripDemand:"LOW",  zone:"cable",      pool:[
-    { name:"Cable Lateral Raise",          reps:15, weight:7,   muscle:"Lateral delt",     vid:"gsC3pd6lfKY", loadType:"total" },
-    { name:"Cable Rear Delt Fly",          reps:15, weight:9,   muscle:"Rear delts",       vid:"ywMSCem375A", loadType:"total" },
-    { name:"Leaning Lateral Raise",        reps:12, weight:7,   muscle:"Lateral delt",     vid:"qWif_7SOYpQ", loadType:"per_db" },
-    { name:"Lateral Raise",                reps:15, weight:7,   muscle:"Lateral delt",     vid:"v_ZkxWzYnMc", loadType:"per_db" },
-    { name:"Band Lateral Raise",           reps:15, weight:null,muscle:"Lateral delt",     vid:"yfNg5sFndbw", loadType:"bodyweight" },
+  "css1-B":{ gripDemand:"LOW", zone:"cable", loadProfile:"light_high_rep", pool:[
+    { name:"Cable Lateral Raise",          reps:15, weight:7,   muscle:"Lateral delt",     vid:"gsC3pd6lfKY", loadType:"total", loadProfile:"light_high_rep" },
+    { name:"Cable Rear Delt Fly",          reps:15, weight:9,   muscle:"Rear delts",       vid:"ywMSCem375A", loadType:"total", loadProfile:"light_high_rep" },
+    { name:"Leaning Lateral Raise",        reps:12, weight:7,   muscle:"Lateral delt",     vid:"qWif_7SOYpQ", loadType:"per_db", loadProfile:"light_high_rep" },
+    { name:"Lateral Raise",                reps:15, weight:7,   muscle:"Lateral delt",     vid:"v_ZkxWzYnMc", loadType:"per_db", loadProfile:"light_high_rep" },
+    { name:"Band Lateral Raise",           reps:15, weight:null,muscle:"Lateral delt",     vid:"yfNg5sFndbw", loadType:"bodyweight", loadProfile:"light_high_rep" },
   ]},
-  "css2-A":{ gripDemand:"MED",  zone:"db",         pool:[
-    { name:"Incline DB Press",             reps:10, weight:26, muscle:"Upper chest",      vid:"ou6s32mJgjU", loadType:"per_db" },
-    { name:"DB Chest Fly",                 reps:12, weight:14, muscle:"Chest / medial",   vid:"eozdVDA78K0", loadType:"per_db" },
-    { name:"Low-to-High Cable Fly",        reps:12, weight:10, muscle:"Upper pec",        vid:"eQ_NBB6OBH4", loadType:"total" },
-    { name:"DB Floor Press",               reps:10, weight:22, muscle:"Chest",            vid:"uUGDRwge4F8", loadType:"per_db" },
-    { name:"Neutral-Grip DB Press",        reps:10, weight:24, muscle:"Chest",            vid:"VzZe73G4vIs", loadType:"per_db" },
-    { name:"Decline Push-Up",              reps:15, weight:null,muscle:"Upper chest",     vid:"SKPab2YC8BE", loadType:"bodyweight" },
+  "css2-A":{ gripDemand:"MED", zone:"db", loadProfile:"moderate_mid_rep", pool:[
+    { name:"Incline DB Press",             reps:10, weight:26, muscle:"Upper chest",      vid:"ou6s32mJgjU", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+    { name:"DB Chest Fly",                 reps:12, weight:14, muscle:"Chest / medial",   vid:"eozdVDA78K0", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+    { name:"Low-to-High Cable Fly",        reps:12, weight:10, muscle:"Upper pec",        vid:"eQ_NBB6OBH4", loadType:"total", loadProfile:"moderate_mid_rep" },
+    { name:"DB Floor Press",               reps:10, weight:22, muscle:"Chest",            vid:"uUGDRwge4F8", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+    { name:"Neutral-Grip DB Press",        reps:10, weight:24, muscle:"Chest",            vid:"VzZe73G4vIs", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+    { name:"Decline Push-Up",              reps:15, weight:null,muscle:"Upper chest",     vid:"SKPab2YC8BE", loadType:"bodyweight", loadProfile:"moderate_mid_rep" },
   ]},
-  "css2-B":{ gripDemand:"MED",  zone:"cable",      pool:[
-    { name:"Seated Cable Row",             reps:10, weight:45, muscle:"Mid back",         vid:"7BkgqzC6WsM", loadType:"total" },
-    { name:"Cable Straight-Arm Pulldown",  reps:12, weight:22, muscle:"Lats",             vid:"98W63pVdW38", loadType:"total" },
-    { name:"Single-Arm Cable Row",         reps:10, weight:22, muscle:"Mid back",         vid:"9TWiV80cUYs", loadType:"total" },
-    { name:"Wide-Grip Cable Row",          reps:10, weight:40, muscle:"Mid back",         vid:"AEM5A06yV9Q", loadType:"total" },
-    { name:"Face-Away Cable Row",          reps:10, weight:26, muscle:"Mid back",         vid:"WYCnIThgbB8", loadType:"total" },
-    { name:"Half-Kneeling Cable Row",      reps:10, weight:22, muscle:"Mid back",         vid:"afE9JabFqR4", loadType:"total" },
+  "css2-B":{ gripDemand:"MED", zone:"cable", loadProfile:"moderate_mid_rep", pool:[
+    { name:"Seated Cable Row",             reps:10, weight:45, muscle:"Mid back",         vid:"7BkgqzC6WsM", loadType:"total", loadProfile:"moderate_mid_rep" },
+    { name:"Cable Straight-Arm Pulldown",  reps:12, weight:22, muscle:"Lats",             vid:"98W63pVdW38", loadType:"total", loadProfile:"moderate_mid_rep" },
+    { name:"Single-Arm Cable Row",         reps:10, weight:22, muscle:"Mid back",         vid:"9TWiV80cUYs", loadType:"total", loadProfile:"moderate_mid_rep" },
+    { name:"Wide-Grip Cable Row",          reps:10, weight:40, muscle:"Mid back",         vid:"AEM5A06yV9Q", loadType:"total", loadProfile:"moderate_mid_rep" },
+    { name:"Face-Away Cable Row",          reps:10, weight:26, muscle:"Mid back",         vid:"WYCnIThgbB8", loadType:"total", loadProfile:"moderate_mid_rep" },
+    { name:"Half-Kneeling Cable Row",      reps:10, weight:22, muscle:"Mid back",         vid:"afE9JabFqR4", loadType:"total", loadProfile:"moderate_mid_rep" },
   ]},
-  "css3-A":{ gripDemand:"HIGH", zone:"db",         pool:[
-    { name:"DB Curl",                      reps:12, weight:10, muscle:"Biceps",           vid:"XE_pHwbst04", loadType:"per_db" },
-    { name:"Incline DB Curl",              reps:12, weight:8,  muscle:"Biceps",           vid:"DCe8f6vMe9A", loadType:"per_db" },
-    { name:"Hammer Curl",                  reps:12, weight:10, muscle:"Biceps & brachialis", vid:"BRVDS6HVR9Q", loadType:"per_db" },
-    { name:"EZ Bar Curl",                  reps:12, weight:18, muscle:"Biceps",           vid:"5NsFLGUf0Fo", loadType:"barbell" },
-    { name:"Concentration Curl",           reps:10, weight:8,  muscle:"Biceps",           vid:"oPGBZHIxusU", loadType:"per_db" },
-    { name:"Preacher Curl",                reps:12, weight:14, muscle:"Biceps",           vid:"GNO4OtYoCYk", loadType:"barbell" },
-    { name:"Zottman Curl",                 reps:10, weight:8,  muscle:"Biceps & forearms", vid:"ZrpRBgswtHs", loadType:"per_db" },
+  "css3-A":{ gripDemand:"HIGH", zone:"db", loadProfile:"moderate_mid_rep", pool:[
+    { name:"DB Curl",                      reps:12, weight:10, muscle:"Biceps",           vid:"XE_pHwbst04", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+    { name:"Incline DB Curl",              reps:12, weight:8,  muscle:"Biceps",           vid:"DCe8f6vMe9A", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+    { name:"Hammer Curl",                  reps:12, weight:10, muscle:"Biceps & brachialis", vid:"BRVDS6HVR9Q", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+    { name:"EZ Bar Curl",                  reps:12, weight:18, muscle:"Biceps",           vid:"5NsFLGUf0Fo", loadType:"barbell", loadProfile:"moderate_mid_rep" },
+    { name:"Concentration Curl",           reps:10, weight:8,  muscle:"Biceps",           vid:"oPGBZHIxusU", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+    { name:"Preacher Curl",                reps:12, weight:14, muscle:"Biceps",           vid:"GNO4OtYoCYk", loadType:"barbell", loadProfile:"moderate_mid_rep" },
+    { name:"Zottman Curl",                 reps:10, weight:8,  muscle:"Biceps & forearms", vid:"ZrpRBgswtHs", loadType:"per_db", loadProfile:"moderate_mid_rep" },
   ]},
-  "css3-B":{ gripDemand:"LOW",  zone:"db", pool:[
-    { name:"Skullcrusher",                 reps:12, weight:18,  muscle:"Triceps",         vid:"OQ4TWXkZjTc", loadType:"barbell" },
-    { name:"Overhead Tricep Extension",    reps:12, weight:14,  muscle:"Triceps",         vid:"iKX6vEhrGxw", loadType:"per_db" },
-    { name:"Close-Grip Push-Up",           reps:15, weight:null,muscle:"Triceps",         vid:"F1Lq9LnyvVc", loadType:"bodyweight" },
-    { name:"Diamond Push-Up",              reps:12, weight:null,muscle:"Triceps",         vid:"kGhDnFwMY3E", loadType:"bodyweight" },
-    { name:"DB Kickback",                  reps:12, weight:8,   muscle:"Triceps",         vid:"m9me06UBPKc", loadType:"per_db" },
-    { name:"Bench Dips",                   reps:15, weight:null,muscle:"Triceps",         vid:"JBCdL6vOoOY", loadType:"bodyweight" },
+  "css3-B":{ gripDemand:"LOW", zone:"db", loadProfile:"moderate_mid_rep", pool:[
+    { name:"Skullcrusher",                 reps:12, weight:18,  muscle:"Triceps",         vid:"OQ4TWXkZjTc", loadType:"barbell", loadProfile:"moderate_mid_rep" },
+    { name:"Overhead Tricep Extension",    reps:12, weight:14,  muscle:"Triceps",         vid:"iKX6vEhrGxw", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+    { name:"Close-Grip Push-Up",           reps:15, weight:null,muscle:"Triceps",         vid:"F1Lq9LnyvVc", loadType:"bodyweight", loadProfile:"moderate_mid_rep" },
+    { name:"Diamond Push-Up",              reps:12, weight:null,muscle:"Triceps",         vid:"kGhDnFwMY3E", loadType:"bodyweight", loadProfile:"moderate_mid_rep" },
+    { name:"DB Kickback",                  reps:12, weight:8,   muscle:"Triceps",         vid:"m9me06UBPKc", loadType:"per_db", loadProfile:"moderate_mid_rep" },
+    { name:"Bench Dips",                   reps:15, weight:null,muscle:"Triceps",         vid:"JBCdL6vOoOY", loadType:"bodyweight", loadProfile:"moderate_mid_rep" },
   ]},
-  "cfin-A":{ gripDemand:"LOW",  zone:"cable",      pool:[
-    { name:"Face Pull",                    reps:15, weight:12,  muscle:"Rear delts / cuff", vid:"cuyx9G1bEwg", loadType:"total" },
-    { name:"Band Face Pull",               reps:15, weight:null,muscle:"Rear delts / cuff", vid:"2RX2OYWlHcU", loadType:"bodyweight" },
-    { name:"Rear Delt Fly",                reps:15, weight:6,   muscle:"Rear delts",        vid:"KoRDmXocJII", loadType:"per_db" },
-    { name:"Cable Rear Delt Fly",          reps:15, weight:8,   muscle:"Rear delts",        vid:"ywMSCem375A", loadType:"total" },
-    { name:"Prone Y Raise",                reps:12, weight:3,   muscle:"Rear delts / cuff", vid:"juoKsTqy77E", loadType:"per_db" },
-    { name:"Band Pull-Apart",              reps:20, weight:null,muscle:"Rear delts / cuff", vid:"stwYTTPXubo", loadType:"bodyweight" },
+  "cfin-A":{ gripDemand:"LOW", zone:"cable", loadProfile:"light_high_rep", pool:[
+    { name:"Face Pull",                    reps:15, weight:12,  muscle:"Rear delts / cuff", vid:"cuyx9G1bEwg", loadType:"total", loadProfile:"light_high_rep" },
+    { name:"Band Face Pull",               reps:15, weight:null,muscle:"Rear delts / cuff", vid:"2RX2OYWlHcU", loadType:"bodyweight", loadProfile:"light_high_rep" },
+    { name:"Rear Delt Fly",                reps:15, weight:6,   muscle:"Rear delts",        vid:"KoRDmXocJII", loadType:"per_db", loadProfile:"light_high_rep" },
+    { name:"Cable Rear Delt Fly",          reps:15, weight:8,   muscle:"Rear delts",        vid:"ywMSCem375A", loadType:"total", loadProfile:"light_high_rep" },
+    { name:"Prone Y Raise",                reps:12, weight:3,   muscle:"Rear delts / cuff", vid:"juoKsTqy77E", loadType:"per_db", loadProfile:"light_high_rep" },
+    { name:"Band Pull-Apart",              reps:20, weight:null,muscle:"Rear delts / cuff", vid:"stwYTTPXubo", loadType:"bodyweight", loadProfile:"light_high_rep" },
   ]},
-  "cfin-B":{ gripDemand:"NONE", zone:"cable",      pool:[
-    { name:"Low-to-High Cable Crossover",  reps:15, weight:9,   muscle:"Upper pec / medial", vid:"u5X5x1fw_SA", loadType:"total" },
-    { name:"DB Chest Fly",                 reps:15, weight:10,  muscle:"Chest / medial",     vid:"eozdVDA78K0", loadType:"per_db" },
-    { name:"Pec Deck",                     reps:15, weight:30,  muscle:"Chest / medial",     vid:"g3T7LsEeDWQ", loadType:"machine" },
-    { name:"Cable Crossover",              reps:15, weight:12,  muscle:"Chest / medial",     vid:"taI4XduLpTk", loadType:"total" },
-    { name:"Single-Arm Cable Fly",         reps:12, weight:8,   muscle:"Chest / medial",     vid:"lCAAPoM_98Q", loadType:"total" },
-    { name:"Svend Press",                  reps:15, weight:8,   muscle:"Chest / medial",     vid:"f7XwzvAhR8Y", loadType:"per_db" },
+  "cfin-B":{ gripDemand:"NONE", zone:"cable", loadProfile:"light_high_rep", pool:[
+    { name:"Low-to-High Cable Crossover",  reps:15, weight:9,   muscle:"Upper pec / medial", vid:"u5X5x1fw_SA", loadType:"total", loadProfile:"light_high_rep" },
+    { name:"DB Chest Fly",                 reps:15, weight:10,  muscle:"Chest / medial",     vid:"eozdVDA78K0", loadType:"per_db", loadProfile:"light_high_rep" },
+    { name:"Pec Deck",                     reps:15, weight:30,  muscle:"Chest / medial",     vid:"g3T7LsEeDWQ", loadType:"machine", loadProfile:"light_high_rep" },
+    { name:"Cable Crossover",              reps:15, weight:12,  muscle:"Chest / medial",     vid:"taI4XduLpTk", loadType:"total", loadProfile:"light_high_rep" },
+    { name:"Single-Arm Cable Fly",         reps:12, weight:8,   muscle:"Chest / medial",     vid:"lCAAPoM_98Q", loadType:"total", loadProfile:"light_high_rep" },
+    { name:"Svend Press",                  reps:15, weight:8,   muscle:"Chest / medial",     vid:"f7XwzvAhR8Y", loadType:"per_db", loadProfile:"light_high_rep" },
   ]},
 };
 
@@ -310,16 +310,25 @@ function recentNamesFor(historyEntry) {
 export function rotateAccessories(history = {}) {
   const config = {};
 
-  // First pass: independent pick per slot, excluding up to N recent selections.
-  Object.entries(EXERCISE_POOLS).forEach(([key, { pool }]) => {
+  // First pass: independent pick per slot, excluding up to N recent selections
+  // and filtering by the slot's load profile (so a heavy-low-rep movement
+  // never rotates into a finisher slot, and vice versa). Profile filtering is
+  // a no-op for slots that don't declare one.
+  Object.entries(EXERCISE_POOLS).forEach(([key, slot]) => {
+    const { pool, loadProfile } = slot;
     const recent = recentNamesFor(history[key]);
-    const available = pool.filter(ex => !recent.includes(ex.name));
-    // Fallback ladder: if 3-block exclusion empties the pool, relax to just
-    // the immediately-prior pick; if even that empties, accept any.
+    const onProfile = loadProfile
+      ? pool.filter(ex => ex.loadProfile === loadProfile)
+      : pool;
+    const available = onProfile.filter(ex => !recent.includes(ex.name));
+    // Fallback ladder: if 3-block exclusion empties the on-profile pool,
+    // relax exclusion (but keep the profile filter — we never cross profiles).
+    // If even the profile filter empties, accept any pool entry as last resort.
     let candidates = available;
     if (candidates.length === 0 && recent.length > 1) {
-      candidates = pool.filter(ex => ex.name !== recent[0]);
+      candidates = onProfile.filter(ex => ex.name !== recent[0]);
     }
+    if (candidates.length === 0) candidates = onProfile;
     if (candidates.length === 0) candidates = pool;
     config[key] = candidates[Math.floor(Math.random() * candidates.length)];
   });

--- a/tests/programme.test.js
+++ b/tests/programme.test.js
@@ -38,11 +38,11 @@ describe("EXERCISE_POOLS pool[0] === SESSIONS default", () => {
 
   // Every pool's pool[0] must equal the SESSIONS default for that slot
   // across every field the engine reads: name, reps, weight, muscle, vid,
-  // loadType. Any drift makes the rotation engine present a different
-  // exercise on the first session of a new block than the home screen
-  // advertises, which silently invalidates muscle-anchor lookups and
+  // loadType, loadProfile. Any drift makes the rotation engine present a
+  // different exercise on the first session of a new block than the home
+  // screen advertises, which silently invalidates muscle-anchor lookups and
   // confuses users.
-  const fields = ["name", "reps", "weight", "muscle", "vid", "loadType"];
+  const fields = ["name", "reps", "weight", "muscle", "vid", "loadType", "loadProfile"];
 
   for (const [key, slot] of Object.entries(EXERCISE_POOLS)) {
     it(`${key} pool[0] matches SESSIONS default on every field`, () => {
@@ -113,6 +113,31 @@ describe("findRecentDays — local timezone handling", () => {
 
   it("daysBack=0 returns empty list", () => {
     expect(findRecentDays([], 0)).toEqual([]);
+  });
+});
+
+// ─── Load-profile invariants ────────────────────────────────────────────────
+describe("EXERCISE_POOLS loadProfile invariants", () => {
+  const VALID_PROFILES = new Set([
+    "heavy_low_rep", "moderate_mid_rep", "light_high_rep", "metabolic",
+  ]);
+
+  it("every slot declares a valid loadProfile", () => {
+    for (const [key, slot] of Object.entries(EXERCISE_POOLS)) {
+      expect(slot.loadProfile, `${key} missing loadProfile`).toBeTruthy();
+      expect(VALID_PROFILES.has(slot.loadProfile), `${key}.loadProfile invalid: ${slot.loadProfile}`).toBe(true);
+    }
+  });
+
+  it("every pool entry's loadProfile matches its slot's loadProfile", () => {
+    // This is the rotation-safety invariant: it prevents a heavy-low-rep
+    // movement from leaking into a finisher slot's pool (or vice versa), so
+    // future pool edits can't silently produce out-of-profile rotations.
+    for (const [key, slot] of Object.entries(EXERCISE_POOLS)) {
+      for (const ex of slot.pool) {
+        expect(ex.loadProfile, `${key} pool entry "${ex.name}" missing loadProfile`).toBe(slot.loadProfile);
+      }
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Tier 2 #5 part **2 of 3** — Rotation V2.

Every exercise instance in `SESSIONS` and `EXERCISE_POOLS` now carries a `loadProfile` field, and every `EXERCISE_POOLS` slot declares an expected `loadProfile`. The rotation engine filters candidates by this profile so a heavy-low-rep movement can never rotate into a finisher slot (and vice versa), and the same invariant is enforced by a vitest test so future pool edits can't silently drift.

## Categories

Per the reference data in the project doc:

| Profile | Use |
|---|---|
| `heavy_low_rep` | Main lifts, sub-6 reps |
| `moderate_mid_rep` | Accessories, 8–12 reps |
| `light_high_rep` | Finishers / isolation, 12–20 reps |
| `metabolic` | Conditioning — reserved for Tier 3 Hyrox additions |

## Slot → profile mapping

All 20 `EXERCISE_POOLS` slots are tagged. All accessory superset slots are `moderate_mid_rep` **except** `css1-B` (`light_high_rep` — the lateral-raise slot introduced in #71, where the pool members are all 12–15 rep isolation work). All finisher slots (`afin*`/`bfin*`/`cfin*`) are `light_high_rep`. SESSIONS main lifts (`a1`/`a2`/`b1`/`b2`/`c1`) are `heavy_low_rep`.

## Per-instance, not per-name

The same exercise *name* can carry different profiles in different pools when programmed at different intensities — e.g. **DB Chest Fly** appears in `css2-A` at 12 reps as `moderate_mid_rep` and in `cfin-B` at 15 reps as `light_high_rep`. Same movement, different programming. `loadProfile` is a per-instance field, like `reps`/`weight`.

## Engine

```js
// rotateAccessories — first pass, per slot:
const onProfile = loadProfile
  ? pool.filter(ex => ex.loadProfile === loadProfile)
  : pool;
const available = onProfile.filter(ex => !recent.includes(ex.name));
// Fallback ladder: relax recency exclusion, but keep the profile filter
// as the inner invariant — we never cross profiles.
```

- **Backward compatible:** slots without a `loadProfile` field are treated as "any profile" (no-op filter), so the rollout is safe.
- **Fallback ladder** preserves the profile filter as the inner invariant: only recency exclusion gets relaxed if a pool is exhausted.

## Tests (+2 invariants)

- Every slot declares one of the 4 valid profiles.
- Every pool entry's `loadProfile` matches its slot's `loadProfile` — prevents future pool edits from leaking a heavy lift into a finisher slot.
- Existing `pool[0] === SESSIONS default` invariant test now also covers the `loadProfile` field, so SESSIONS defaults and `pool[0]` stay in lockstep on the new field too.

## Diff size

147 exercise instances + 20 slot declarations tagged (167 new `loadProfile` occurrences). Mechanical tagging done via a one-shot script (not committed — discarded after the edit); engine + tests by hand.

## Test plan

- [x] `npm test` → 189/189 (incl. new invariants).
- [x] `npm run audit:volume` → still "no flags".
- [x] `npm run lint` → clean.
- [x] `npx next build` → clean.
- [ ] Manually rotate on the preview — verify rotation picks are unchanged (the filter is enforcing a property already true of every current pool entry, so it should be a no-op in production).

## Part of Rotation V2 series

- ✅ **PR-1 (#72, merged):** 3-block memory.
- **PR-2 (this):** `loadProfile` tag + slot filter.
- **PR-3 (next):** Anatomy-aware rotation summary card.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gucgxvub2JW5XT1q9dhU8f)_