### PR TITLE
Rotation V2: anatomy-aware summary card (per-muscle stimulus delta)

### DIFF
--- a/components/ForgeApp.jsx
+++ b/components/ForgeApp.jsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import {
   WEEK, STRENGTH_DAY_SESSIONS, SESSIONS,
-  EXERCISE_POOLS, rotateAccessories, rotationDiff, pushHistoryBlock,
+  EXERCISE_POOLS, rotateAccessories, rotationDiff, pushHistoryBlock, computeRotationStimulusDelta,
   ROTATION_OPTIONAL, ROTATION_AUTO, ROTATION_FORCED,
   DAY_CONFIG, DAY_NAMES, SWAP_DB, EQ_COLOUR,
   // Retrospective logging helpers (compute past-date programme metadata + missing-day detection)
@@ -19,7 +19,7 @@ import {
   newDraftLog, logSet, finaliseDraft, scaleForReadiness, D, TS,
   inferLoadType, LOAD_TYPES, startingWeightForLift,
 } from "@/lib/storage";
-import { T } from "@/lib/tokens";
+import { T, MUSCLE_COLOURS } from "@/lib/tokens";
 import {
   computeNextPrescription,
   updateLiftStateFromSession,
@@ -1034,7 +1034,8 @@ const sProps={
     PB.save(next);
     if (showSummary) {
       const changes = rotationDiff(oldConfig, newConfig);
-      setRotationSummary({ blockNumber: next.number, changes });
+      const stimulusDelta = computeRotationStimulusDelta(oldConfig, newConfig);
+      setRotationSummary({ blockNumber: next.number, changes, stimulusDelta });
     }
     return next;
   };
@@ -3313,6 +3314,8 @@ function SwapOverlay({activeEx,swapKey,onSwap,onClose}){
 function RotationSummaryModal({summary,onContinue}){
   const {gold}=T;
   const count = summary.changes.length;
+  // Top 4 by magnitude — enough to tell the story, not enough to overwhelm.
+  const topDeltas = (summary.stimulusDelta || []).slice(0, 4);
   return (
     <div style={{position:"fixed",inset:0,background:"rgba(10,9,8,0.94)",zIndex:400,display:"flex",alignItems:"flex-end",justifyContent:"center"}}>
       <div style={{background:T.bg2,borderRadius:`${T.r.lg}px ${T.r.lg}px 0 0`,padding:"28px 24px 32px",width:"100%",maxWidth:430,borderTop:`1px solid ${gold}44`,animation:`slideUp 280ms ${T.ease}`,maxHeight:"85vh",display:"flex",flexDirection:"column"}}>
@@ -3322,9 +3325,31 @@ function RotationSummaryModal({summary,onContinue}){
         <div style={{fontFamily:T.serif,fontSize:30,fontWeight:300,lineHeight:1.15,marginBottom:8}}>
           Your programme<br/><span style={{color:gold,fontStyle:"italic"}}>has rotated.</span>
         </div>
-        <p style={{fontSize:13,color:T.text2,marginBottom:20,lineHeight:1.6}}>
+        <p style={{fontSize:13,color:T.text2,marginBottom:topDeltas.length?14:20,lineHeight:1.6}}>
           {count} {count===1?"accessory":"accessories"} swapped to keep the stimulus fresh. Main lifts stay the same — progressive overload continues.
         </p>
+        {topDeltas.length > 0 && (
+          <div style={{marginBottom:20}}>
+            <div style={{fontSize:10,fontWeight:500,color:T.text3,letterSpacing:"0.12em",textTransform:"uppercase",marginBottom:8}}>
+              This block · muscle stimulus
+            </div>
+            <div style={{display:"flex",flexWrap:"wrap",gap:6}}>
+              {topDeltas.map(({bucket, delta}) => {
+                const positive = delta > 0;
+                const colour = MUSCLE_COLOURS[bucket] || MUSCLE_COLOURS.Other;
+                return (
+                  <div key={bucket} style={{display:"inline-flex",alignItems:"center",gap:6,padding:"5px 10px",borderRadius:T.r.sm,background:T.bg3,border:`1px solid ${colour}66`}}>
+                    <span style={{width:8,height:8,borderRadius:"50%",background:colour,display:"inline-block"}} aria-hidden="true"/>
+                    <span style={{fontSize:11,fontWeight:500,color:positive?colour:T.text3,fontVariantNumeric:"tabular-nums"}}>
+                      {positive?"+":""}{delta.toFixed(1)}
+                    </span>
+                    <span style={{fontSize:11,color:T.text2}}>{bucket}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
         <div style={{flex:1,overflowY:"auto",marginBottom:20,marginRight:-8,paddingRight:8}}>
           {count===0 && (
             <div style={{padding:"20px 0",fontSize:13,color:T.text3,fontStyle:"italic",fontFamily:T.serif,textAlign:"center"}}>

--- a/lib/programme.js
+++ b/lib/programme.js
@@ -6,6 +6,8 @@
 // ForgeApp.jsx and any future analytics routes import from here.
 // ─────────────────────────────────────────────────────────────────────────────
 
+import { distributeAcrossMuscles, DISPLAY_BUCKET } from "./exercise-anatomy.js";
+
 // ─── Weekly schedule ──────────────────────────────────────────────────────────
 export const WEEK = [
   { s:"M", label:"Strength", type:"strength" },
@@ -376,6 +378,66 @@ export function rotationDiff(oldConfig, newConfig) {
     }
   });
   return changes;
+}
+
+// ─── Slot key → SESSIONS sets count (memoised lazily) ────────────────────────
+// Slot keys in EXERCISE_POOLS are "<blockId>-<A|B>". The block's `sets` count
+// is the multiplier the muscle-stimulus delta uses to compare configs honestly:
+// a 3-set superset changes muscle exposure by 3× the per-rep difference between
+// old and new movements, not 1×.
+let _slotSetsCache = null;
+function slotSetsMap() {
+  if (_slotSetsCache) return _slotSetsCache;
+  const m = {};
+  for (const sess of SESSIONS) {
+    for (const block of sess.blocks) {
+      if (block.exA) m[`${block.id}-A`] = block.sets;
+      if (block.exB) m[`${block.id}-B`] = block.sets;
+      if (block.ex)  m[block.id] = block.sets;
+    }
+  }
+  _slotSetsCache = m;
+  return m;
+}
+
+// Compute the per-(display-bucket)-muscle stimulus delta between two configs.
+// Positive value = new config delivers MORE weighted sets to that muscle this
+// block; negative = less. Drives the anatomy-aware rotation summary card.
+//
+// Aggregation matches lib/analytics.js: each slot's sets count is distributed
+// across muscles by exercise anatomy (primary 1.0 + weighted secondaries) via
+// distributeAcrossMuscles, then bucketed to the 9 display groups so the UI
+// shares vocabulary with the Performance Lab.
+//
+// @param {Record<string, {name:string, muscle?:string}>} oldConfig
+// @param {Record<string, {name:string, muscle?:string}>} newConfig
+// @returns {Array<{bucket:string, delta:number}>}  sorted by |delta| desc
+export function computeRotationStimulusDelta(oldConfig = {}, newConfig = {}) {
+  const sets = slotSetsMap();
+  const totals = {}; // displayBucket → net delta
+  const keys = new Set([...Object.keys(oldConfig || {}), ...Object.keys(newConfig || {})]);
+
+  for (const key of keys) {
+    const setsCount = sets[key];
+    if (!setsCount) continue;
+    const oldEx = oldConfig?.[key] || EXERCISE_POOLS[key]?.pool?.[0];
+    const newEx = newConfig?.[key] || EXERCISE_POOLS[key]?.pool?.[0];
+    if (!oldEx?.name || !newEx?.name || oldEx.name === newEx.name) continue;
+
+    const oldContrib = distributeAcrossMuscles(oldEx.name, setsCount, oldEx.muscle);
+    const newContrib = distributeAcrossMuscles(newEx.name, setsCount, newEx.muscle);
+    const muscles = new Set([...Object.keys(oldContrib), ...Object.keys(newContrib)]);
+    for (const m of muscles) {
+      const bucket = DISPLAY_BUCKET[m] || m;
+      const d = (newContrib[m] || 0) - (oldContrib[m] || 0);
+      if (d !== 0) totals[bucket] = (totals[bucket] || 0) + d;
+    }
+  }
+
+  return Object.entries(totals)
+    .map(([bucket, delta]) => ({ bucket, delta: Math.round(delta * 10) / 10 }))
+    .filter(({ delta }) => delta !== 0)
+    .sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta));
 }
 
 // ─── Home screen config ────────────────────────────────────────────────────────

--- a/tests/programme.test.js
+++ b/tests/programme.test.js
@@ -19,6 +19,7 @@ import {
   findRecentDays,
   rotateAccessories,
   pushHistoryBlock,
+  computeRotationStimulusDelta,
   ROTATION_MEMORY_BLOCKS,
 } from "../lib/programme.js";
 
@@ -231,5 +232,87 @@ describe("pushHistoryBlock", () => {
     const active = { "ass1-A": null, "ass1-B": { name: "Cable Row" } };
     const next = pushHistoryBlock({}, active);
     expect(next).toEqual({ "ass1-B": ["Cable Row"] });
+  });
+});
+
+// ─── Anatomy-aware rotation summary ────────────────────────────────────────
+describe("computeRotationStimulusDelta", () => {
+  it("returns empty for empty/identical configs", () => {
+    expect(computeRotationStimulusDelta({}, {})).toEqual([]);
+    const same = { "ass1-A": EXERCISE_POOLS["ass1-A"].pool[0] };
+    expect(computeRotationStimulusDelta(same, same)).toEqual([]);
+  });
+
+  it("ignores slots where the exercise name didn't change", () => {
+    const ex = EXERCISE_POOLS["ass1-A"].pool[0];
+    const oldCfg = { "ass1-A": ex };
+    const newCfg = { "ass1-A": { ...ex } }; // same name, different object
+    expect(computeRotationStimulusDelta(oldCfg, newCfg)).toEqual([]);
+  });
+
+  it("nets gains and losses per display bucket, sorted by magnitude", () => {
+    // Build a config delta we can predict: swap css1-B (3 sets, light_high_rep
+    // slot, lateral-raise themed) from Cable Lateral Raise → Cable Rear Delt Fly.
+    // Both feed Shoulders bucket, but the contribution shifts (side-delt → rear-delt).
+    const slot = EXERCISE_POOLS["css1-B"];
+    const lateralRaise = slot.pool.find((p) => p.name === "Cable Lateral Raise");
+    const rearDeltFly = slot.pool.find((p) => p.name === "Cable Rear Delt Fly");
+    expect(lateralRaise).toBeTruthy();
+    expect(rearDeltFly).toBeTruthy();
+
+    const delta = computeRotationStimulusDelta(
+      { "css1-B": lateralRaise },
+      { "css1-B": rearDeltFly },
+    );
+
+    // Both contribute to Shoulders; Cable Rear Delt Fly also feeds Back via
+    // its 0.25 secondary, so Back should appear with a positive delta.
+    const bucketMap = Object.fromEntries(delta.map((d) => [d.bucket, d.delta]));
+    expect(bucketMap.Back).toBeGreaterThan(0);
+    // Sorted by absolute magnitude
+    for (let i = 1; i < delta.length; i++) {
+      expect(Math.abs(delta[i - 1].delta)).toBeGreaterThanOrEqual(Math.abs(delta[i].delta));
+    }
+  });
+
+  it("scales by the slot's sets count (3-set superset weighs 3× a 1-set change)", () => {
+    // Use the same slot (sets=3 for css1-B) — verify the delta magnitude is
+    // 3× what distributeAcrossMuscles would give for a single set.
+    const slot = EXERCISE_POOLS["css1-B"];
+    const lateralRaise = slot.pool.find((p) => p.name === "Cable Lateral Raise");
+    const rearDeltFly = slot.pool.find((p) => p.name === "Cable Rear Delt Fly");
+    const delta = computeRotationStimulusDelta(
+      { "css1-B": lateralRaise },
+      { "css1-B": rearDeltFly },
+    );
+    // css1-B has sets=3 in SESSIONS, so the back-bucket delta (rearDeltFly's
+    // 0.25 back secondary) should be ~3 * 0.25 = 0.75 (rounded to 1dp = 0.8 or 0.7).
+    const back = delta.find((d) => d.bucket === "Back");
+    expect(back.delta).toBeGreaterThanOrEqual(0.7);
+    expect(back.delta).toBeLessThanOrEqual(0.8);
+  });
+
+  it("falls back to pool[0] when a slot is missing in either config", () => {
+    // newConfig has the slot, oldConfig doesn't — should treat the missing
+    // side as the SESSIONS default (pool[0]).
+    const slot = EXERCISE_POOLS["css1-B"];
+    const rearDeltFly = slot.pool.find((p) => p.name === "Cable Rear Delt Fly");
+    const delta = computeRotationStimulusDelta({}, { "css1-B": rearDeltFly });
+    // pool[0] is Cable Lateral Raise (per the rebalance), so this is the
+    // lateralRaise → rearDeltFly delta — should report a non-empty change.
+    expect(delta.length).toBeGreaterThan(0);
+  });
+
+  it("rounds deltas to 1 decimal place", () => {
+    const oldCfg = {};
+    for (const [k, slot] of Object.entries(EXERCISE_POOLS)) oldCfg[k] = slot.pool[0];
+    const newCfg = { ...oldCfg };
+    // Force one change so the function does work
+    const slot = EXERCISE_POOLS["css1-B"];
+    newCfg["css1-B"] = slot.pool[1];
+    const delta = computeRotationStimulusDelta(oldCfg, newCfg);
+    for (const d of delta) {
+      expect(d.delta).toBe(Math.round(d.delta * 10) / 10);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Tier 2 #5 part **3 of 3** — closes Rotation V2.

The rotation summary modal now surfaces the *why* of each rotation, not just the *what*. Beneath the headline it shows the top muscle-bucket stimulus shifts this block — e.g. **"+2.4 Shoulders · −1.8 Glutes · +0.6 Back"** — computed by distributing each changed slot's sets across muscles via exercise anatomy and netting old vs new per display bucket.

## Engine

New `computeRotationStimulusDelta(oldConfig, newConfig)` pure helper in `lib/programme.js`. For each slot whose exercise name changed, it multiplies the slot's `SESSIONS` `sets` count by the per-muscle anatomy distribution of old vs new movement, sums across all changes, buckets to the 9 display groups, and returns the deltas sorted by magnitude.

Aggregation matches `lib/analytics.js` exactly — same `distributeAcrossMuscles` + `DISPLAY_BUCKET` pipeline — so the summary card speaks the same per-muscle vocabulary as the Performance Lab.

```
Sample sanity run (synthetic full rotation):
  -3.8  Arms
  -2.1  Shoulders
  +0.6  Core
  +0.6  Chest
  +0.3  Hamstrings
  -0.3  Calves
  +0.2  Back
  -0.1  Quads
```

## UI

`RotationSummaryModal` in `components/ForgeApp.jsx`: top 4 deltas rendered as coloured pills above the per-slot change list, using `MUSCLE_COLOURS`. Positive deltas show in the bucket's accent colour; negative in muted text. Tabular-nums for stable alignment. No render when there are no deltas (degenerate "rotation ran but same picks held" case preserves the original UI cleanly).

## Tests (+6)

- Empty / identical / same-name configs return `[]`.
- Output sorted by magnitude.
- Set-count scaling correct (`sets=3` ⇒ 3× the per-rep delta).
- `pool[0]` fallback when a slot is missing from either config.
- Deltas rounded to 1 decimal place.

## Test plan

- [x] `npm test` → 195/195.
- [x] `npm run lint` → clean.
- [x] `npx next build` → clean.
- [ ] Trigger a manual rotation in the preview — verify the pill row renders above the change list, colours match Performance Lab, signs read correctly.

## Rotation V2 series

- ✅ **PR-1 (#72, merged):** 3-block memory.
- ✅ **PR-2 (#73, merged):** `loadProfile` tag + slot filter.
- **PR-3 (this):** Anatomy-aware rotation summary card.

This PR closes Tier 2 #5. Next up: Tier 2 #6 (main-lift functional rotation + Olympic-comfort onboarding) — the last item in the high-value Tier 2 batch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gucgxvub2JW5XT1q9dhU8f)_