### PR TITLE
Main-lift functional swaps: load-profile-honest substitutes

### DIFF
--- a/lib/programme.js
+++ b/lib/programme.js
@@ -280,6 +280,27 @@ export const SS_PAIRS = [
   ["css1-A","css1-B"], ["css2-A","css2-B"], ["css3-A","css3-B"],
 ];
 
+// ─── Main-lift functional equivalents ───────────────────────────────────────
+// The approved substitution lists for each main lift. Engine consumers
+// (Olympic-comfort onboarding, future main-lift rotation) read this map; the
+// SWAP_DB entries above must align with it (enforced by an invariant test).
+//
+// Key constraint: every alternative is heavy_low_rep — a main lift never
+// rotates to a lighter substitute (the progressive-overload spine of the
+// programme). For Power Clean, Kettlebell Swing is explicitly excluded — it's
+// a finisher movement, wrong load profile.
+//
+// For the doc's "Trap Bar variants" entry under Hex Bar DL: Hex Bar IS a trap
+// bar, so high-handle vs low-handle is a setup choice rather than a separate
+// movement. Captured by the existing default rather than a swap.
+export const MAIN_LIFT_FUNCTIONAL_EQUIVALENTS = {
+  "Barbell Back Squat":     ["Front Squat", "Hack Squat"],
+  "Barbell Bench Press":    ["Dumbbell Bench Press", "Incline BB Press", "DB Floor Press", "Weighted Dips"],
+  "Hex Bar Deadlift":       ["Sumo Deadlift", "Romanian Deadlift"],
+  "Barbell Overhead Press": ["Dumbbell Shoulder Press", "Push Press", "Arnold Press"],
+  "Power Clean":            ["Hang Power Clean", "Push Press"],
+};
+
 // ─── Rotation thresholds (in weeks on current block) ─────────────────────────
 export const ROTATION_OPTIONAL = 4;   // "rotate now" card appears on home
 export const ROTATION_AUTO     = 8;   // auto-rotate before next session starts
@@ -463,13 +484,16 @@ export const EQ_COLOUR = {
 };
 
 export const SWAP_DB = {
-  "Barbell Back Squat":        [{ name:"Goblet Squat",              eq:"Dumbbell",  muscle:"Quadriceps",          vid:"9W5KAqHfDe8" },
-                                { name:"Bulgarian Split Squat",     eq:"Dumbbell",  muscle:"Quads & Glutes",      vid:"uODWo4YqbT8" },
-                                { name:"Leg Press",                 eq:"Machine",   muscle:"Quads & Glutes",      vid:"nDh_BlnLCGc" },
+  // Main-lift swaps: heavy_low_rep functional equivalents only. Light
+  // substitutes (Goblet Squat, Push-Up, Glute Bridge etc.) are deliberately
+  // excluded — a main lift swapped to a lighter movement breaks progressive
+  // overload continuity. Source list: MAIN_LIFT_FUNCTIONAL_EQUIVALENTS below.
+  "Barbell Back Squat":        [{ name:"Front Squat",               eq:"Barbell",   muscle:"Quadriceps",          vid:null },
                                 { name:"Hack Squat",                eq:"Machine",   muscle:"Quadriceps",          vid:"hrciyIRwFzs" }],
-  "Barbell Bench Press":       [{ name:"Dumbbell Bench Press",      eq:"Dumbbell",  muscle:"Chest",               vid:null },
-                                { name:"Push-Up",                   eq:"Bodyweight",muscle:"Chest",               vid:null },
-                                { name:"DB Floor Press",            eq:"Dumbbell",  muscle:"Chest",               vid:"uUGDRwge4F8" }],
+  "Barbell Bench Press":       [{ name:"Dumbbell Bench Press",            eq:"Dumbbell",  muscle:"Chest",               vid:null },
+                                { name:"Incline BB Press",          eq:"Barbell",   muscle:"Upper chest",         vid:null },
+                                { name:"DB Floor Press",            eq:"Dumbbell",  muscle:"Chest",               vid:"uUGDRwge4F8" },
+                                { name:"Weighted Dips",             eq:"Bodyweight",muscle:"Chest / Triceps",     vid:null }],
   "Barbell Reverse Lunge":     [{ name:"DB Reverse Lunge",          eq:"Dumbbell",  muscle:"Quads & Glutes",      vid:"RZKXLMxPF_I" },
                                 { name:"Step-Up",                   eq:"Bodyweight",muscle:"Quads & Glutes",      vid:null },
                                 { name:"Split Squat",               eq:"Bodyweight",muscle:"Quads & Glutes",      vid:null }],
@@ -488,12 +512,11 @@ export const SWAP_DB = {
                                 { name:"Reverse Crunch",            eq:"Bodyweight",muscle:"Core",                vid:null }],
   "Dead Bug":                  [{ name:"Hollow Body Hold",          eq:"Bodyweight",muscle:"Core / Anti-rot",     vid:"LlDNef_Ztsc" },
                                 { name:"Plank",                     eq:"Bodyweight",muscle:"Core",                vid:null }],
-  "Hex Bar Deadlift":          [{ name:"Romanian Deadlift",         eq:"Barbell",   muscle:"Posterior chain",     vid:"hCDzSR6bW10" },
-                                { name:"Dumbbell Deadlift",         eq:"Dumbbell",  muscle:"Posterior chain",     vid:null },
-                                { name:"Sumo Deadlift",             eq:"Barbell",   muscle:"Posterior chain",     vid:null }],
-  "Barbell Overhead Press":    [{ name:"Dumbbell Shoulder Press",   eq:"Dumbbell",  muscle:"Shoulders",           vid:null },
-                                { name:"Arnold Press",              eq:"Dumbbell",  muscle:"Shoulders",           vid:null },
-                                { name:"Push Press",                eq:"Barbell",   muscle:"Shoulders",           vid:null }],
+  "Hex Bar Deadlift":          [{ name:"Sumo Deadlift",             eq:"Barbell",   muscle:"Posterior chain",     vid:null },
+                                { name:"Romanian Deadlift",         eq:"Barbell",   muscle:"Posterior chain",     vid:"hCDzSR6bW10" }],
+  "Barbell Overhead Press":    [{ name:"Dumbbell Shoulder Press",         eq:"Dumbbell",  muscle:"Shoulders",           vid:null },
+                                { name:"Push Press",                eq:"Barbell",   muscle:"Shoulders",           vid:null },
+                                { name:"Arnold Press",              eq:"Dumbbell",  muscle:"Shoulders",           vid:null }],
   "Leg Press":                 [{ name:"Goblet Squat",              eq:"Dumbbell",  muscle:"Quads & Glutes",      vid:"9W5KAqHfDe8" },
                                 { name:"Bulgarian Split Squat",     eq:"Dumbbell",  muscle:"Quads & Glutes",      vid:"uODWo4YqbT8" },
                                 { name:"Wall Sit",                  eq:"Bodyweight",muscle:"Quadriceps",          vid:null }],
@@ -514,9 +537,12 @@ export const SWAP_DB = {
   "Cable Lateral Raise":       [{ name:"Lateral Raise",             eq:"Dumbbell",  muscle:"Lateral delt",        vid:"v_ZkxWzYnMc" },
                                 { name:"Leaning Lateral Raise",     eq:"Dumbbell",  muscle:"Lateral delt",        vid:"qWif_7SOYpQ" },
                                 { name:"Band Lateral Raise",        eq:"Band",      muscle:"Lateral delt",        vid:"yfNg5sFndbw" }],
+  // Power Clean swap: Hang Power Clean is the first-choice equivalent for
+  // experienced lifters; Push Press is the heavy non-Olympic alternative.
+  // Kettlebell Swing is explicitly REJECTED — it's a finisher movement, not a
+  // main-lift load profile.
   "Power Clean":               [{ name:"Hang Power Clean",          eq:"Barbell",   muscle:"Full body / explosive",vid:null },
-                                { name:"Dumbbell Hang Clean",       eq:"Dumbbell",  muscle:"Full body / explosive",vid:null },
-                                { name:"Kettlebell Swing",          eq:"Kettlebell",muscle:"Posterior chain",     vid:null }],
+                                { name:"Push Press",                eq:"Barbell",   muscle:"Shoulders",           vid:null }],
   "DB Walking Lunge":          [{ name:"Reverse Lunge",             eq:"Bodyweight",muscle:"Quads & Glutes",      vid:null },
                                 { name:"Step-Up",                   eq:"Bodyweight",muscle:"Quads & Glutes",      vid:null },
                                 { name:"Split Squat",               eq:"Bodyweight",muscle:"Quads & Glutes",      vid:null }],

--- a/tests/exercise-library.test.js
+++ b/tests/exercise-library.test.js
@@ -105,6 +105,11 @@ const PATTERN_MATCHED_ALLOWLIST = new Set([
   "Rope Tricep Pushdown",
   "Single-Arm Pushdown",
   "Smith Calf Raise",
+  // Main-lift functional swaps (Tier 2 #6) — resolved correctly by the
+  // pattern matcher (squat / press / dips → standard primaries).
+  "Front Squat",
+  "Incline BB Press",
+  "Weighted Dips",
 ]);
 
 describe("exercise library — programme coverage", () => {

--- a/tests/programme.test.js
+++ b/tests/programme.test.js
@@ -16,11 +16,13 @@ import { describe, it, expect } from "vitest";
 import {
   SESSIONS,
   EXERCISE_POOLS,
+  SWAP_DB,
   findRecentDays,
   rotateAccessories,
   pushHistoryBlock,
   computeRotationStimulusDelta,
   ROTATION_MEMORY_BLOCKS,
+  MAIN_LIFT_FUNCTIONAL_EQUIVALENTS,
 } from "../lib/programme.js";
 
 // ─── Pool[0] invariant ──────────────────────────────────────────────────────
@@ -313,6 +315,71 @@ describe("computeRotationStimulusDelta", () => {
     const delta = computeRotationStimulusDelta(oldCfg, newCfg);
     for (const d of delta) {
       expect(d.delta).toBe(Math.round(d.delta * 10) / 10);
+    }
+  });
+});
+
+// ─── Main-lift functional equivalents ───────────────────────────────────────
+describe("MAIN_LIFT_FUNCTIONAL_EQUIVALENTS ↔ SWAP_DB alignment", () => {
+  // Every main lift in MAIN_LIFT_FUNCTIONAL_EQUIVALENTS must correspond to an
+  // actual SESSIONS main-lift block.
+  it("every main-lift key is a current SESSIONS main lift", () => {
+    const sessionMains = new Set();
+    for (const sess of SESSIONS) {
+      for (const block of sess.blocks) {
+        if (block.type === "main" && block.ex?.name) sessionMains.add(block.ex.name);
+      }
+    }
+    for (const lift of Object.keys(MAIN_LIFT_FUNCTIONAL_EQUIVALENTS)) {
+      expect(sessionMains.has(lift), `${lift} not a SESSIONS main lift`).toBe(true);
+    }
+  });
+
+  // Every functional equivalent listed must appear in SWAP_DB for that lift,
+  // so users can actually pick it from the swap overlay.
+  it("every equivalent appears in SWAP_DB[lift]", () => {
+    for (const [lift, equivalents] of Object.entries(MAIN_LIFT_FUNCTIONAL_EQUIVALENTS)) {
+      const swapNames = new Set((SWAP_DB[lift] || []).map((s) => s.name));
+      expect(SWAP_DB[lift], `SWAP_DB missing entry for ${lift}`).toBeTruthy();
+      for (const eq of equivalents) {
+        expect(swapNames.has(eq), `${lift} SWAP_DB missing ${eq}`).toBe(true);
+      }
+    }
+  });
+
+  // No drift the other way: SWAP_DB for a main lift shouldn't contain
+  // alternatives that aren't in the approved equivalents list (would mean a
+  // lighter substitute leaked in, breaking the load-profile principle).
+  it("SWAP_DB[main-lift] contains ONLY approved equivalents", () => {
+    for (const [lift, equivalents] of Object.entries(MAIN_LIFT_FUNCTIONAL_EQUIVALENTS)) {
+      const approved = new Set(equivalents);
+      for (const swap of SWAP_DB[lift] || []) {
+        expect(approved.has(swap.name), `${lift} SWAP_DB has unapproved alt ${swap.name}`).toBe(true);
+      }
+    }
+  });
+
+  // Doc-specified explicit prohibition: Kettlebell Swing must never appear
+  // as a Power Clean substitute (it's a finisher, wrong load profile).
+  it("Kettlebell Swing is NOT a Power Clean substitute", () => {
+    const powerCleanSwaps = (SWAP_DB["Power Clean"] || []).map((s) => s.name);
+    expect(powerCleanSwaps).not.toContain("Kettlebell Swing");
+    expect(MAIN_LIFT_FUNCTIONAL_EQUIVALENTS["Power Clean"]).not.toContain("Kettlebell Swing");
+  });
+
+  // Documented load-profile lighter-substitutes that historically lived in
+  // main-lift swap pools must NOT return — regression guard.
+  it("known lighter substitutes are not in main-lift swap pools", () => {
+    const forbidden = {
+      "Barbell Back Squat":  ["Goblet Squat", "Bulgarian Split Squat", "Leg Press"],
+      "Barbell Bench Press": ["Push-Up"],
+      "Hex Bar Deadlift":    ["Dumbbell Deadlift"],
+    };
+    for (const [lift, names] of Object.entries(forbidden)) {
+      const swapNames = new Set((SWAP_DB[lift] || []).map((s) => s.name));
+      for (const n of names) {
+        expect(swapNames.has(n), `${lift} SWAP_DB regressed: contains lighter ${n}`).toBe(false);
+      }
     }
   });
 });


### PR DESCRIPTION
## Summary

Tier 2 #6 part **1 of 2** (PR-A — Olympic-comfort onboarding follows in PR-B).

The existing `SWAP_DB` main-lift entries contained **lighter substitutes** — Goblet Squat for Back Squat, Push-Up for Bench, Dumbbell DL for Hex Bar DL, Kettlebell Swing for Power Clean. A main lift swapped to a lighter movement breaks progressive-overload continuity, which is the spine of the programme. This PR rewrites all five main-lift swap pools to the doc-approved `heavy_low_rep` functional equivalents only, plus exports a canonical `MAIN_LIFT_FUNCTIONAL_EQUIVALENTS` map for the engine.

**Behavioural change: zero.** Main lifts still don't auto-rotate; this just upgrades what the user-initiated swap overlay offers. Existing beta-cohort progression continues unchanged.

## On scope: why swap-only, not auto-rotate

The doc says *"A main lift rotates only to functional equivalents at the SAME load profile"* — which could mean (a) auto-rotate at the 4/8/12-week thresholds like accessories, or (b) user-initiated swap only. Auto-rotate would silently shift existing beta users from Barbell Back Squat → Front Squat at week 8 and break the `RotationSummaryModal`'s promise *"Main lifts stay the same — progressive overload continues."* This PR takes the swap-only interpretation. If you later want auto-rotation enabled, it's an additive change with a modal-copy update.

## Swap-pool changes

| Main lift | Before | After |
|---|---|---|
| Barbell Back Squat | Goblet Squat, Bulgarian SS, Leg Press, Hack Squat | **Front Squat, Hack Squat** |
| Barbell Bench Press | Dumbbell Bench, Push-Up, DB Floor Press | **Dumbbell Bench Press, Incline BB Press, DB Floor Press, Weighted Dips** |
| Hex Bar Deadlift | Romanian DL, Dumbbell DL, Sumo DL | **Sumo DL, Romanian DL** |
| Barbell OHP | Dumbbell Shoulder Press, Arnold Press, Push Press | **Dumbbell Shoulder Press, Push Press, Arnold Press** (no change — already aligned) |
| Power Clean | Hang Power Clean, DB Hang Clean, **Kettlebell Swing** | **Hang Power Clean, Push Press** |

**KB Swing is doc-explicit REJECTED** for Power Clean — it's a finisher movement (wrong load profile).

**Trap Bar variants** (Hex Bar DL): Hex Bar *is* a trap bar; high-handle vs low-handle is a setup choice, not a separate movement. Captured by the existing default rather than a swap entry.

## New canonical map

```js
export const MAIN_LIFT_FUNCTIONAL_EQUIVALENTS = {
  "Barbell Back Squat":     ["Front Squat", "Hack Squat"],
  "Barbell Bench Press":    ["Dumbbell Bench Press", "Incline BB Press", "DB Floor Press", "Weighted Dips"],
  "Hex Bar Deadlift":       ["Sumo Deadlift", "Romanian Deadlift"],
  "Barbell Overhead Press": ["Dumbbell Shoulder Press", "Push Press", "Arnold Press"],
  "Power Clean":            ["Hang Power Clean", "Push Press"],
};
```

Source of truth for the engine — consumed by PR-B's Olympic-comfort onboarding (maps "No / Some / Yes" → seeded Day C default) and any future main-lift rotation logic.

## Tests (+5)

- Every `MAIN_LIFT_FUNCTIONAL_EQUIVALENTS` key is a current SESSIONS main lift.
- Every listed equivalent appears in `SWAP_DB` for that lift (forward alignment).
- `SWAP_DB[main-lift]` contains ONLY approved equivalents (backward — no drift / no lighter substitute leak).
- Kettlebell Swing is explicitly NOT a Power Clean substitute.
- Regression guard: known-removed lighter substitutes (Goblet Squat, Push-Up, Dumbbell DL) don't return.

## Naming + anatomy housekeeping

- Used the codebase canonical `Dumbbell Bench Press` / `Dumbbell Shoulder Press` rather than the doc's `DB ...` abbreviation. The 7-name canonicalisation principle from the project history governs.
- New names without explicit `EXERCISE_ANATOMY` entries (`Front Squat`, `Incline BB Press`, `Weighted Dips`) added to `PATTERN_MATCHED_ALLOWLIST` in `tests/exercise-library.test.js` — they resolve correctly via the existing squat / press / dips patterns. No anatomy dataset edits (load-bearing design principle).

## Test plan

- [x] `npm test` → 200/200 (incl. all new invariants + existing canonical-name and anatomy-coverage tests).
- [x] `npm run lint` → clean.
- [x] `npx next build` → clean.
- [x] `npm run audit:volume` → still no flags.
- [ ] On preview, swap a main lift via the swap overlay — verify the new options appear and the previously-lighter ones don't.

## Part of Tier 2 #6

- **PR-A (this):** Swap-pool rewrites + `MAIN_LIFT_FUNCTIONAL_EQUIVALENTS` map.
- **PR-B (next):** Olympic-comfort onboarding question + `forge:olympicComfort` storage + Day C default seeding for new profiles.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gucgxvub2JW5XT1q9dhU8f)_