### PR TITLE
Performance Lab: actionable volume-vs-MEV/MAV/MRV card

### DIFF
--- a/components/PerformanceLab.jsx
+++ b/components/PerformanceLab.jsx
@@ -5,6 +5,7 @@ import {
   mainLiftTrend, weeklyVolume, consistencyGrid,
   readinessBreakdown, sessionCount, detectPlateaus,
 } from "@/lib/analytics";
+import { auditHistoryVolume } from "@/lib/volume-audit";
 import { T, MUSCLE_COLOURS } from "@/lib/tokens";
 
 // ─── Main export ──────────────────────────────────────────────────────────────
@@ -15,6 +16,7 @@ export default function PerformanceLab({ history, onBack }) {
   const readiness = useMemo(() => readinessBreakdown(history), [history]);
   const counts    = useMemo(() => sessionCount(history),       [history]);
   const plateaus  = useMemo(() => detectPlateaus(history),     [history]);
+  const volumeAudit = useMemo(() => auditHistoryVolume(history, { weeks: 4 }), [history]);
 
   const mainLifts = Object.keys(trends);
   const [selectedLift, setSelectedLift] = useState(null);
@@ -77,6 +79,13 @@ export default function PerformanceLab({ history, onBack }) {
           <Card title="Weekly volume" subtitle="Sets per muscle group · last 8 weeks">
             <VolumeChart weeks={volume.slice(-8)} />
             <VolumeLegend data={volume.slice(-8)} />
+          </Card>
+
+          {/* Volume vs MEV/MAV/MRV — actionable: which muscles are below the
+              productive floor or above the recoverable ceiling, based on the
+              last 4 weeks of ACTUAL training (not the static programme audit). */}
+          <Card title="Volume vs landmarks" subtitle="Last 4 weeks · MEV/MAV/MRV bands">
+            <VolumeStatusCard audit={volumeAudit} />
           </Card>
 
           {/* Consistency heatmap */}
@@ -275,6 +284,73 @@ function VolumeLegend({ data }) {
           <span style={{fontSize:10, color:T.text3, fontWeight:500}}>{m}</span>
         </div>
       ))}
+    </div>
+  );
+}
+
+// ─── Volume status card (MEV/MAV/MRV bands on actual training) ──────────────
+// Surfaces the muscles that need attention this block: below MEV (not driving
+// growth) or above MRV (junk volume / recovery cost). Hides for new users who
+// don't have enough recent sessions for the audit to mean anything.
+function VolumeStatusCard({ audit }) {
+  // Need at least ~2 weeks of training (≥4 sessions) before the audit is
+  // signal vs noise. Below that, encourage logging rather than fire warnings.
+  if (!audit || audit.sessionsAnalysed < 4) {
+    return (
+      <div style={{padding:"14px 0 2px", fontSize:13, color:T.text3, fontStyle:"italic", fontFamily:T.serif, lineHeight:1.5}}>
+        A few more logged sessions and this card will start flagging muscles below MEV or above MRV.
+      </div>
+    );
+  }
+
+  const under = audit.flags.filter(f => f.status === "under_mev");
+  const over  = audit.flags.filter(f => f.status === "over_mrv");
+
+  if (under.length === 0 && over.length === 0) {
+    return (
+      <div style={{padding:"14px 0 2px", fontSize:13, color:T.text2, lineHeight:1.5}}>
+        ✓ Every targeted muscle is within MEV..MRV this block. Keep the rhythm.
+      </div>
+    );
+  }
+
+  const Pill = ({ status, muscle, sets, target }) => {
+    const colour = status === "over_mrv" ? T.gold : T.rose;
+    const label  = status === "over_mrv" ? `${sets} > MRV ${target.mrv}` : `${sets} < MEV ${target.mev}`;
+    return (
+      <div style={{display:"inline-flex",alignItems:"center",gap:8,padding:"6px 10px",borderRadius:T.r.sm,background:T.bg3,border:`1px solid ${colour}44`}}>
+        <span style={{width:8,height:8,borderRadius:"50%",background:colour,display:"inline-block"}} aria-hidden="true"/>
+        <span style={{fontSize:12,color:T.text1,fontWeight:500}}>{muscle}</span>
+        <span style={{fontSize:11,color:T.text3,fontVariantNumeric:"tabular-nums"}}>{label}</span>
+      </div>
+    );
+  };
+
+  return (
+    <div style={{padding:"4px 0 2px"}}>
+      {under.length > 0 && (
+        <div style={{marginBottom:over.length>0?14:0}}>
+          <div style={{fontSize:10,fontWeight:500,color:T.text3,letterSpacing:"0.12em",textTransform:"uppercase",marginBottom:8}}>
+            Below MEV · won&apos;t drive growth
+          </div>
+          <div style={{display:"flex",flexWrap:"wrap",gap:6}}>
+            {under.map(f => <Pill key={f.muscle} {...f}/>)}
+          </div>
+        </div>
+      )}
+      {over.length > 0 && (
+        <div>
+          <div style={{fontSize:10,fontWeight:500,color:T.text3,letterSpacing:"0.12em",textTransform:"uppercase",marginBottom:8}}>
+            Above MRV · recovery cost
+          </div>
+          <div style={{display:"flex",flexWrap:"wrap",gap:6}}>
+            {over.map(f => <Pill key={f.muscle} {...f}/>)}
+          </div>
+        </div>
+      )}
+      <div style={{marginTop:14,fontSize:11,color:T.text4,lineHeight:1.5}}>
+        Audited over {audit.weeksAnalysed} weeks · {audit.sessionsAnalysed} session{audit.sessionsAnalysed===1?"":"s"}
+      </div>
     </div>
   );
 }

--- a/lib/volume-audit.js
+++ b/lib/volume-audit.js
@@ -129,3 +129,80 @@ export function auditVolume(sessions = SESSIONS, { targets = VOLUME_TARGETS } = 
 
   return { perMuscle, flags };
 }
+
+// ─── Live training audit (from logged history) ──────────────────────────────
+// Audit the user's ACTUAL recent training, not just the static programme. Same
+// MEV/MAV/MRV vocabulary as auditVolume above — but the input is logged
+// history sessions, and sets are averaged across the trailing window so a
+// "weekly" volume is honest regardless of which days the user trained.
+//
+// Aggregation matches lib/exercise-anatomy.js#aggregateBucketedVolume:
+// non-empty sets are counted, exercise anatomy distributes the set count
+// across primary + secondary muscles. We keep the GRANULAR muscle vocabulary
+// (not display-bucketed) so MEV/MAV/MRV per delt head and per-arm-muscle
+// stays honest.
+//
+// Returns the same shape as auditVolume PLUS metadata the UI needs to decide
+// whether to surface the card at all (a 3-day-old user with 1 session
+// shouldn't get a wall of "under MEV" warnings).
+//
+// @param {Array} [history]  Session log records (newest-first or any order).
+// @param {{weeks?:number, targets?:typeof VOLUME_TARGETS, now?:Date}} [opts]
+// @returns {{
+//   perMuscle: Record<string,{sets:number,target:object|null,status:string}>,
+//   flags:     Array<{muscle:string,status:string,sets:number,target:object|null}>,
+//   weeksAnalysed: number,
+//   sessionsAnalysed: number,
+// }}
+export function auditHistoryVolume(
+  history = [],
+  { weeks = 4, targets = VOLUME_TARGETS, now = new Date() } = {},
+) {
+  // Window = trailing N weeks. Today is the right-edge; oldest = today - 7N days.
+  const oldest = new Date(now);
+  oldest.setHours(0, 0, 0, 0);
+  oldest.setDate(oldest.getDate() - weeks * 7);
+
+  const inWindow = (history || []).filter((rec) => {
+    if (!rec?.date) return false;
+    return new Date(rec.date) >= oldest;
+  });
+
+  const totals = {};
+  for (const session of inWindow) {
+    for (const block of session.blocks || []) {
+      for (const ex of block.exercises || []) {
+        // A "completed" set has either a logged weight or reps — matches the
+        // counting rule in exercise-anatomy.js#aggregateBucketedVolume so
+        // both surfaces (chart + audit) agree on the same sessions.
+        const setsCount = (ex.sets || []).filter((s) => s.weight !== null || s.reps).length;
+        if (setsCount === 0) continue;
+        const contrib = distributeAcrossMuscles(ex.name, setsCount, ex.muscle);
+        for (const [muscle, value] of Object.entries(contrib)) {
+          totals[muscle] = (totals[muscle] || 0) + value;
+        }
+      }
+    }
+  }
+
+  // Convert cumulative-window totals to PER-WEEK average so the comparison
+  // against weekly landmarks is apples-to-apples. Use the requested window
+  // span (not "weeks observed in history") so a user training 2 weeks out of
+  // 4 correctly reports half-volume rather than full.
+  const perMuscle = {};
+  const muscles = [
+    ...AUDIT_MUSCLE_ORDER,
+    ...Object.keys(totals).filter((m) => !AUDIT_MUSCLE_ORDER.includes(m)),
+  ];
+  for (const muscle of muscles) {
+    const sets = round1((totals[muscle] || 0) / weeks);
+    const target = targets[muscle] || null;
+    perMuscle[muscle] = { sets, target, status: classifyVolume(sets, target) };
+  }
+
+  const flags = Object.entries(perMuscle)
+    .filter(([, r]) => r.status === "under_mev" || r.status === "over_mrv")
+    .map(([muscle, r]) => ({ muscle, status: r.status, sets: r.sets, target: r.target }));
+
+  return { perMuscle, flags, weeksAnalysed: weeks, sessionsAnalysed: inWindow.length };
+}

--- a/tests/volume-audit.test.js
+++ b/tests/volume-audit.test.js
@@ -11,6 +11,7 @@ import {
   computeWeeklyVolume,
   classifyVolume,
   auditVolume,
+  auditHistoryVolume,
   VOLUME_TARGETS,
 } from "../lib/volume-audit.js";
 import { MUSCLES } from "../lib/exercise-anatomy.js";
@@ -137,5 +138,116 @@ describe("invariant — targets stay in lockstep with MUSCLES", () => {
     for (const m of Object.keys(VOLUME_TARGETS)) {
       expect(valid.has(m), `${m} is not a MUSCLES value`).toBe(true);
     }
+  });
+});
+
+// ─── auditHistoryVolume (live training audit) ───────────────────────────────
+describe("auditHistoryVolume", () => {
+  // Helper: build a history record at a date with one named exercise + N sets
+  function rec(date, exercises) {
+    return { date, blocks: [{ exercises }] };
+  }
+  function setN(n, { weight = 50, reps = 5 } = {}) {
+    return Array.from({ length: n }, () => ({ weight, reps }));
+  }
+  const NOW = new Date("2026-05-31T12:00:00Z");
+
+  it("returns zero / empty for an empty history", () => {
+    const a = auditHistoryVolume([], { weeks: 4, now: NOW });
+    expect(a.sessionsAnalysed).toBe(0);
+    expect(a.weeksAnalysed).toBe(4);
+    for (const m of Object.keys(VOLUME_TARGETS)) {
+      expect(a.perMuscle[m].sets).toBe(0);
+    }
+  });
+
+  it("counts only sessions inside the trailing window", () => {
+    const inside = "2026-05-25"; // 6 days before NOW
+    const outside = "2026-04-01"; // way before
+    const history = [
+      rec(inside,  [{ name: "Barbell Back Squat", muscle: "Quadriceps", sets: setN(3) }]),
+      rec(outside, [{ name: "Barbell Back Squat", muscle: "Quadriceps", sets: setN(3) }]),
+    ];
+    const a = auditHistoryVolume(history, { weeks: 4, now: NOW });
+    expect(a.sessionsAnalysed).toBe(1);
+  });
+
+  it("averages cumulative-window sets across the requested weeks", () => {
+    // 1 session, 3 squat sets, audited over a 4-week window
+    // → 3/4 = 0.75 sets/wk for Quads from the primary, rounded to 0.8
+    const history = [
+      rec("2026-05-25", [{ name: "Barbell Back Squat", muscle: "Quadriceps", sets: setN(3) }]),
+    ];
+    const a = auditHistoryVolume(history, { weeks: 4, now: NOW });
+    expect(a.perMuscle.Quads.sets).toBeCloseTo(0.8, 1);
+  });
+
+  it("distributes sets across primary + secondary muscles via anatomy", () => {
+    // Squat anatomy: Quads primary 1.0, Glutes 0.5, Hams 0.25, Core 0.3, Calves 0.15
+    const history = [
+      rec("2026-05-25", [{ name: "Barbell Back Squat", muscle: "Quadriceps", sets: setN(4) }]),
+    ];
+    const a = auditHistoryVolume(history, { weeks: 4, now: NOW });
+    expect(a.perMuscle.Quads.sets).toBeGreaterThan(0);
+    expect(a.perMuscle.Glutes.sets).toBeGreaterThan(0);
+    expect(a.perMuscle.Hamstrings.sets).toBeGreaterThan(0);
+    expect(a.perMuscle.Quads.sets).toBeGreaterThan(a.perMuscle.Glutes.sets);
+  });
+
+  it("ignores sets where weight is null AND reps absent (matches chart counting)", () => {
+    const history = [
+      rec("2026-05-25", [{
+        name: "Hanging Leg Raise", muscle: "Core",
+        sets: [{ weight: null }, { weight: null, reps: 10 }, { weight: 5, reps: 8 }],
+      }]),
+    ];
+    const a = auditHistoryVolume(history, { weeks: 4, now: NOW });
+    // Only 2 of the 3 sets qualify (one is null/no-reps)
+    expect(a.perMuscle.Core.sets).toBeGreaterThan(0);
+    expect(a.perMuscle.Core.sets).toBeLessThan(2);
+  });
+
+  it("flags under_mev and over_mrv on the actual training", () => {
+    // 4 weeks of nothing but heavy squats → Quads through the roof, everything else zero
+    const history = [];
+    for (let i = 0; i < 12; i++) {
+      const d = new Date(NOW);
+      d.setDate(d.getDate() - i * 2);
+      history.push(rec(d.toISOString().slice(0, 10), [
+        { name: "Barbell Back Squat", muscle: "Quadriceps", sets: setN(10) },
+      ]));
+    }
+    const a = auditHistoryVolume(history, { weeks: 4, now: NOW });
+    // Quads getting massive volume — definitely not under MEV (would actually
+    // be over MRV here, which is its own flag; we just confirm it's NOT below).
+    expect(a.perMuscle.Quads.status).not.toBe("under_mev");
+    const underNames = a.flags.filter((f) => f.status === "under_mev").map((f) => f.muscle);
+    expect(underNames).toContain("Chest");
+    expect(underNames).toContain("Back");
+  });
+
+  it("respects custom weeks parameter", () => {
+    const history = [
+      rec("2026-05-25", [{ name: "Barbell Back Squat", muscle: "Quadriceps", sets: setN(8) }]),
+    ];
+    // Same cumulative volume → smaller window = higher per-week average
+    const a4 = auditHistoryVolume(history, { weeks: 4, now: NOW });
+    const a1 = auditHistoryVolume(history, { weeks: 1, now: NOW });
+    expect(a1.perMuscle.Quads.sets).toBeGreaterThan(a4.perMuscle.Quads.sets);
+    expect(a1.weeksAnalysed).toBe(1);
+    expect(a4.weeksAnalysed).toBe(4);
+  });
+
+  it("guards against missing dates / malformed records", () => {
+    const a = auditHistoryVolume([
+      null,
+      {},
+      { date: "2026-05-25" }, // no blocks
+      { date: "2026-05-25", blocks: [{}] }, // no exercises
+    ], { weeks: 4, now: NOW });
+    // null + {} are skipped (no date); the 2 dated-but-empty records count
+    // as "sessions in window" even though they contribute zero volume.
+    expect(a.sessionsAnalysed).toBe(2);
+    expect(a.perMuscle.Quads.sets).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

User-suggestion #9 from the refinement list — actionable volume-vs-MEV/MAV/MRV card in the Performance Lab.

The static volume-audit tool (#70) already classified the programme template against MEV/MAV/MRV. This PR brings the same vocabulary into the user's **actual live training** — surfacing which muscles need attention this block (below MEV, not driving growth) or are being overcooked (above MRV, recovery cost) — based on the trailing 4 weeks of logged sessions.

## Engine

New `auditHistoryVolume(history, opts)` in `lib/volume-audit.js`:
- Filters history to a trailing N-week window (default 4).
- Counts qualifying sets per exercise (same rule as the analytics chart so both surfaces agree on the same sessions).
- Distributes set counts across muscles via exercise anatomy.
- Averages over the window to per-week values.
- Classifies vs `VOLUME_TARGETS`.
- Returns the same shape as `auditVolume` PLUS `weeksAnalysed` / `sessionsAnalysed` so the UI can decide when to surface the card.

Granular muscle vocabulary preserved (per-delt-head + biceps/triceps distinct, not display-bucketed) — *"Rear Delts under MEV"* is more actionable than *"Shoulders under MEV"*.

## UI

`components/PerformanceLab.jsx` — new **"Volume vs landmarks"** card, slotted right after Weekly volume (same data domain, deeper analysis):

- Two sections of pills:
  - **Below MEV · won't drive growth** (rose accent)
  - **Above MRV · recovery cost** (gold accent)
- Each pill: muscle name + sets/wk vs the breached threshold (e.g. *"Rear Delts · 4.9 < MEV 6"*).
- **Hidden state** for new users with < 4 sessions in window: friendly *"a few more logged sessions and this card will start flagging…"* note.
- **All-clear state:** *"✓ Every targeted muscle is within MEV..MRV this block. Keep the rhythm."*
- Footer: *"Audited over N weeks · M sessions"* so the user knows the scope.

## Tests (+8)

Empty history, trailing-window filtering, per-week averaging math, anatomy distribution (primary + secondaries), qualifying-set rule, real-world flag detection, weeks parameter, malformed-record guard.

## Test plan

- [x] `npm test` → 208/208.
- [x] `npm run lint` → clean.
- [x] `npx next build` → clean.
- [x] `npm run audit:volume` → static programme still flag-free.
- [x] On preview: open Performance Lab — verify the new card renders with the expected states (new user → hidden message, mid-block user → pills, mature user → all-clear state).

## Refinement-list status

- ✅ #9 — Under/over-MEV card (this PR).
- ⏭ #2 — RPE/RIR boundary tests (next).
- ⏭ #10 — Programme-config reset button.
- ⏭ #5 + #6 — README + CHANGELOG.
- ⏭ #11 — Editable weekly schedule (2–3 PRs).
- ❌ Dropped per user discussion: Olympic-comfort onboarding (PR-B of #6), static-file consolidation.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gucgxvub2JW5XT1q9dhU8f)_