### PR TITLE
Polish: RPE/RIR boundary tests + programme-config reset

### DIFF
--- a/components/ForgeApp.jsx
+++ b/components/ForgeApp.jsx
@@ -1042,6 +1042,13 @@ const sProps={
 
   const handleRotate = () => rotate(true);
 
+  // Reset rotation drift to SESSIONS defaults (preserves block number/start).
+  // Used by the "Reset accessories" link on home for users who've over-rotated.
+  const handleResetProgramme = () => {
+    const next = PB.reset();
+    setProgrammeBlock(next);
+  };
+
   const beginSession = () => {
     // Auto-rotate if we're past the threshold. Show summary card;
     // once acknowledged, readiness screen follows.
@@ -1464,7 +1471,7 @@ const sProps={
 
   return (
     <div style={{background:T.bg0,minHeight:"100vh",maxWidth:430,margin:"0 auto",fontFamily:T.sans,color:T.text1,WebkitFontSmoothing:"antialiased"}}>
-      {screen==="home"        && <HomeScreen rhythm={rhythm} profileName={activeProfile} onBegin={beginSession} onProfile={()=>setShowProfiles(true)} weekDone={weekDone} onMarkDayDone={handleMarkDayDone} programmeBlock={programmeBlock} weeksOnBlock={weeksOnBlock} onRotate={handleRotate} onPerformance={handleOpenPerformance} historyCount={history.length} recoveryNudge={recoveryNudge} onDismissRecovery={()=>setRecoveryDismissed(true)} syncState={syncState} pendingDraft={pendingDraft} onResumeDraft={handleResumeDraft} onDiscardDraft={handleDiscardDraft} showBwCard={bwIsStale && !bwCardDismissed} onOpenBwEdit={()=>setBwEditOpen(true)} onDismissBwCard={()=>setBwCardDismissed(true)} deloadOffer={deloadOffer} onAcceptDeload={handleAcceptDeload} onDismissDeload={handleDismissDeload} hasRetroGaps={hasRetroGaps} onOpenRetroPicker={handleOpenRetroPicker} retroToast={retroToast} onDismissRetroToast={()=>setRetroToast(null)} pnStage={pnStage} pnBusy={pnBusy} pnError={pnError} pnSuccessToast={pnSuccessToast} onPnRegister={handleRegisterPasskeyFromHome} onPnSnooze={handleSnoozeNudge} onPnDismissToast={()=>setPnSuccessToast(false)}/>}
+      {screen==="home"        && <HomeScreen rhythm={rhythm} profileName={activeProfile} onBegin={beginSession} onProfile={()=>setShowProfiles(true)} weekDone={weekDone} onMarkDayDone={handleMarkDayDone} programmeBlock={programmeBlock} weeksOnBlock={weeksOnBlock} onRotate={handleRotate} onResetProgramme={handleResetProgramme} onPerformance={handleOpenPerformance} historyCount={history.length} recoveryNudge={recoveryNudge} onDismissRecovery={()=>setRecoveryDismissed(true)} syncState={syncState} pendingDraft={pendingDraft} onResumeDraft={handleResumeDraft} onDiscardDraft={handleDiscardDraft} showBwCard={bwIsStale && !bwCardDismissed} onOpenBwEdit={()=>setBwEditOpen(true)} onDismissBwCard={()=>setBwCardDismissed(true)} deloadOffer={deloadOffer} onAcceptDeload={handleAcceptDeload} onDismissDeload={handleDismissDeload} hasRetroGaps={hasRetroGaps} onOpenRetroPicker={handleOpenRetroPicker} retroToast={retroToast} onDismissRetroToast={()=>setRetroToast(null)} pnStage={pnStage} pnBusy={pnBusy} pnError={pnError} pnSuccessToast={pnSuccessToast} onPnRegister={handleRegisterPasskeyFromHome} onPnSnooze={handleSnoozeNudge} onPnDismissToast={()=>setPnSuccessToast(false)}/>}
       {screen==="readiness"   && <ReadinessScreen readiness={readiness} setReadiness={setReadiness} reason={readinessReason} setReason={setReadinessReason} onStart={handleReadinessStart}/>}
       {screen==="session"     && <ErrorBoundary><SessionScreen {...sProps}/></ErrorBoundary>}
       {screen==="done"        && <ErrorBoundary><DoneScreen session={activeSession} profileName={activeProfile} workingWeights={workingWeights} onHome={()=>{ setShowDeloadComplete(false); reset(); }} deloadCompleted={showDeloadComplete}/></ErrorBoundary>}
@@ -2409,7 +2416,23 @@ function ProfileScreen({existing,current,onActivate,onCancel,bodyweight=null,bwE
 }
 
 // ─── Home ──────────────────────────────────��──────────────────────────────────
-function HomeScreen({rhythm,profileName,onBegin,onProfile,weekDone={},onMarkDayDone,programmeBlock,weeksOnBlock,onRotate,onPerformance,historyCount=0,recoveryNudge=null,onDismissRecovery,syncState="idle",pendingDraft=null,onResumeDraft,onDiscardDraft,showBwCard=false,onOpenBwEdit,onDismissBwCard,deloadOffer=null,onAcceptDeload,onDismissDeload,hasRetroGaps=false,onOpenRetroPicker,retroToast=null,onDismissRetroToast,pnStage="hidden",pnBusy=false,pnError=null,pnSuccessToast=false,onPnRegister,onPnSnooze,onPnDismissToast}){
+function HomeScreen({rhythm,profileName,onBegin,onProfile,weekDone={},onMarkDayDone,programmeBlock,weeksOnBlock,onRotate,onResetProgramme,onPerformance,historyCount=0,recoveryNudge=null,onDismissRecovery,syncState="idle",pendingDraft=null,onResumeDraft,onDiscardDraft,showBwCard=false,onOpenBwEdit,onDismissBwCard,deloadOffer=null,onAcceptDeload,onDismissDeload,hasRetroGaps=false,onOpenRetroPicker,retroToast=null,onDismissRetroToast,pnStage="hidden",pnBusy=false,pnError=null,pnSuccessToast=false,onPnRegister,onPnSnooze,onPnDismissToast}){
+  // Two-tap reset confirmation: first tap arms, second tap commits, 5s timeout disarms.
+  const [resetArmed, setResetArmed] = useState(false);
+  const resetTimerRef = useRef(null);
+  const hasRotationDrift = Object.keys(programmeBlock?.config || {}).length > 0;
+  const handleResetTap = () => {
+    if (!resetArmed) {
+      setResetArmed(true);
+      clearTimeout(resetTimerRef.current);
+      resetTimerRef.current = setTimeout(() => setResetArmed(false), 5000);
+      return;
+    }
+    clearTimeout(resetTimerRef.current);
+    setResetArmed(false);
+    onResetProgramme?.();
+  };
+  useEffect(() => () => clearTimeout(resetTimerRef.current), []);
   // Anchor "now" once at mount so render stays pure (no clock read mid-render)
   // and the day-of-week / viewed-date maths derive from a single consistent point.
   const [nowMs]  = useState(() => Date.now());
@@ -2908,6 +2931,19 @@ function HomeScreen({rhythm,profileName,onBegin,onProfile,weekDone={},onMarkDayD
             </div>
           </div>
         </Fade>
+      )}
+
+      {/* Reset accessories — quiet escape hatch for over-rotated users. Only
+          surfaces when there's actual rotation drift to undo. Two-tap confirm
+          inline, no modal, 5s auto-disarm. */}
+      {hasRotationDrift && (
+        <div style={{margin:"16px 24px 0",textAlign:"center"}}>
+          <button
+            onClick={handleResetTap}
+            style={{padding:"6px 10px",background:"none",border:"none",cursor:"pointer",fontSize:11,color:resetArmed?T.rose:T.text4,textDecoration:"underline",textUnderlineOffset:3,fontFamily:T.sans}}>
+            {resetArmed ? "Tap again to reset accessories to defaults" : "Reset accessories to defaults"}
+          </button>
+        </div>
       )}
 
       {/* Performance Lab entry — always visible, becomes active once data exists */}

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -214,6 +214,17 @@ export const PB = {
                      // entries are accepted transparently by rotateAccessories.
   }),
   save: (pb) => LS.set("forge:programmeBlock", pb),
+  // Reset rotation state to SESSIONS defaults — clears `config` (so pool[0]
+  // is served everywhere) and `history` (so the next rotation starts from a
+  // clean exclusion list). Keeps `number` and `startDate` intact so the
+  // user's training-journey counter doesn't reset; only the rotation drift
+  // is undone. Returns the new programmeBlock object.
+  reset: () => {
+    const current = PB.get();
+    const next = { ...current, config: {}, history: {} };
+    LS.set("forge:programmeBlock", next);
+    return next;
+  },
 };
 
 // ─── Vercel Blob sync ────────────────────────────────────────────────────────
@@ -618,6 +629,13 @@ export function rpeToRir(rpe) {
   if (rpe === "hard")   return 1;
   if (rpe === "cooked") return 0;
   if (rpe === "limit")  return 0;  // legacy alias for cooked
+  // null/undefined/"" are legitimate "no RPE logged" signals — silently null.
+  // ANY OTHER non-empty value (typo, future scale, casing drift) is a typo
+  // we want to know about — warn loudly so it surfaces in dev rather than
+  // silently dropping the set's effort signal downstream.
+  if (rpe != null && rpe !== "") {
+    console.warn(`rpeToRir: unrecognised RPE "${rpe}" → null (set will lack effort signal)`);
+  }
   return null;
 }
 

--- a/tests/rpe-rir.test.js
+++ b/tests/rpe-rir.test.js
@@ -1,0 +1,104 @@
+// tests/rpe-rir.test.js
+// ────────────────────────────────────────────────────────────────────────────
+// Boundary + regression tests for the per-set effort mapping. A typo or new
+// scale-label that isn't handled drops the set's RIR to null downstream —
+// progression then can't fire the ADD signal, so a user training "hard" sees
+// the engine just hold. That's the class of bug the "100kg @ hard suggested
+// >100kg" reconciliation fix addressed; this test locks the contract.
+//
+// Contract:
+//   - rpeToRir(known)   → fixed RIR (easy=3, normal=2, hard=1, cooked=0, limit=0)
+//   - rpeToRir(null/"") → null (legitimate "no RPE")
+//   - rpeToRir(other)   → null + console.warn (so typos surface)
+//   - rirToRpe is the inverse for the user-facing 3-point scale
+// ────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { rpeToRir, rirToRpe } from "../lib/storage.js";
+
+describe("rpeToRir — known UI scale (easy / normal / cooked)", () => {
+  it("easy → 3 RIR", () => expect(rpeToRir("easy")).toBe(3));
+  it("normal → 2 RIR", () => expect(rpeToRir("normal")).toBe(2));
+  it("cooked → 0 RIR", () => expect(rpeToRir("cooked")).toBe(0));
+});
+
+describe("rpeToRir — legacy scale (hard / limit) — present-day v1 records", () => {
+  it("hard → 1 RIR", () => expect(rpeToRir("hard")).toBe(1));
+  it("limit → 0 RIR (legacy alias for cooked)", () => expect(rpeToRir("limit")).toBe(0));
+});
+
+describe("rpeToRir — legitimate 'no RPE' inputs (silent null)", () => {
+  let warn;
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  it.each([null, undefined, ""])("%p → null without warning", (input) => {
+    expect(rpeToRir(input)).toBe(null);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("rpeToRir — unknown inputs (null + console.warn for dev visibility)", () => {
+  let warn;
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  it.each([
+    // Casing drift — common typo class. Code base uses lowercase.
+    "Easy", "NORMAL", "Cooked",
+    // Whitespace — easy to fat-finger in URL params or migrated data.
+    " easy", "easy ", " normal ",
+    // Future / unhandled scale labels.
+    "moderate", "max", "rpe7", "rpe10",
+    // Non-string types coerced to a string in JS.
+    "0", "true",
+  ])("%p → null AND console.warn", (input) => {
+    expect(rpeToRir(input)).toBe(null);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0][0])).toContain("unrecognised");
+  });
+
+  it("numeric input → null AND warn (RPE is a string scale, not a number)", () => {
+    // A loose caller passing numeric RPE (common bug across teams who confuse
+    // RPE-the-1-to-10-scale with our 3-point label scale) should be flagged.
+    expect(rpeToRir(7)).toBe(null);
+    expect(warn).toHaveBeenCalled();
+  });
+});
+
+describe("rirToRpe — inverse mapping back to UI labels", () => {
+  it("0 → cooked", () => expect(rirToRpe(0)).toBe("cooked"));
+  it("1 → hard (surfaces only on v1 migration)", () => expect(rirToRpe(1)).toBe("hard"));
+  it("2 → normal", () => expect(rirToRpe(2)).toBe("normal"));
+  it("3 → easy", () => expect(rirToRpe(3)).toBe("easy"));
+  it("higher RIRs collapse to easy (>= 3)", () => {
+    expect(rirToRpe(4)).toBe("easy");
+    expect(rirToRpe(10)).toBe("easy");
+  });
+  it("fractional values band sensibly", () => {
+    expect(rirToRpe(2.5)).toBe("normal");
+    expect(rirToRpe(1.5)).toBe("hard");
+    expect(rirToRpe(0.5)).toBe("cooked");
+  });
+  it("null / undefined return null", () => {
+    expect(rirToRpe(null)).toBe(null);
+    expect(rirToRpe(undefined)).toBe(null);
+  });
+});
+
+describe("rpe ↔ rir round-trip for the live UI scale", () => {
+  // The 3 labels users actually log MUST round-trip through both functions
+  // without drift. (limit/hard are legacy reads only, so they round-trip to
+  // their canonical RIR sibling rather than the legacy label.)
+  it.each([
+    ["easy", "easy"],
+    ["normal", "normal"],
+    ["cooked", "cooked"],
+  ])("%s → rir → %s", (rpe, expected) => {
+    expect(rirToRpe(rpeToRir(rpe))).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary

Two refinements from the user list, packaged as a small polish PR.

## #2 — RPE/RIR boundary tests + dev warning

Locks the `rpeToRir` / `rirToRpe` contract that previously silently dropped the effort signal when an unknown string sneaked in (typo, casing drift, future scale label). The downstream null handling at the two callsites (progression engine, history upgrade) was already defensive — the gap was **observability**, not correctness. Now:

| Input | Output | Side effect |
|---|---|---|
| `"easy"` / `"normal"` / `"hard"` / `"cooked"` / `"limit"` | fixed RIR | none |
| `null` / `undefined` / `""` | `null` | none (legitimate "no RPE") |
| Anything else (typo, casing, future label, number) | `null` | `console.warn` |

The warn surfaces in dev consoles so the next regression doesn't quietly degrade progression for a whole cohort.

**Tests** (`tests/rpe-rir.test.js`, +31): the full known scale, casing drift (`"Easy"`, `"NORMAL"`), whitespace (`" easy "`), future labels (`"moderate"`, `"rpe7"`), numeric inputs, fractional RIR banding for `rirToRpe`, round-trip for the live UI scale (`easy → 3 → easy`).

## #10 — Reset accessories to defaults

Escape hatch for users who've over-rotated and want to back out. Clears `programmeBlock.config` and `programmeBlock.history` → SESSIONS `pool[0]` defaults take over everywhere. **Keeps `number` and `startDate`** so the user's training-journey counter doesn't reset; only the rotation drift is undone.

- `PB.reset()` helper in `lib/storage.js`. Pure: returns the new block object; the UI wires it through `setProgrammeBlock`.
- `handleResetProgramme` in ForgeApp main, passed down to `HomeScreen`.
- Small **"Reset accessories to defaults"** link on home, only visible when there's actual rotation drift to undo. **Two-tap inline confirmation**, 5s auto-disarm, no modal. Always available — independent of `weeksOnBlock`, so a user who instant-regrets a rotation can undo without waiting 4 weeks for the rotate card to surface.

## Test plan

- [x] `npm test` → 239/239 (incl. 31 new RPE/RIR tests).
- [x] `npm run lint` → clean.
- [x] `npx next build` → clean.
- [x] On preview: rotate once → confirm "Reset accessories to defaults" link appears below the rotate card → first tap arms (turns rose, says "Tap again to reset…") → second tap commits → link disappears.
- [x] Briefly verify the dev console doesn't warn on existing valid RPE values.

## Refinement-list status

- ✅ #2 — RPE/RIR boundary tests (this PR).
- ✅ #9 — Under-MEV card (PR #76).
- ✅ #10 — Programme-config reset (this PR).
- ⏭ #5 + #6 — README + CHANGELOG.
- ⏭ #11 — Editable weekly schedule (2–3 PRs).
- ❌ Dropped per user discussion: Olympic-comfort onboarding, static-file consolidation.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gucgxvub2JW5XT1q9dhU8f)_