### PR TITLE
Editable week — PR-A: storage + engine plumbing (no UI yet)

### DIFF
--- a/components/ForgeApp.jsx
+++ b/components/ForgeApp.jsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import {
-  WEEK, STRENGTH_DAY_SESSIONS, SESSIONS,
+  WEEK, SESSIONS, deriveStrengthDaySessions,
   EXERCISE_POOLS, rotateAccessories, rotationDiff, pushHistoryBlock, computeRotationStimulusDelta,
   ROTATION_OPTIONAL, ROTATION_AUTO, ROTATION_FORCED,
   DAY_CONFIG, DAY_NAMES, SWAP_DB, EQ_COLOUR,
@@ -10,7 +10,7 @@ import {
   sessionMetaForDate, findRecentDays, hasMissedStrength,
 } from "@/lib/programme";
 import {
-  LS, P, PB, H, BW, PN, bumpStreak,
+  LS, P, PB, W, H, BW, PN, bumpStreak,
   computeRhythm, detectRecoveryPattern,
   blobPush, flushPendingPushes, getLocalProfile, backgroundSync, SyncStatus,
   enableAutoSync, disableAutoSync,
@@ -367,7 +367,14 @@ export default function ForgeApp(){
   // when there's actually something to fill. If the user trained every strength
   // day in the last 3, the link stays hidden and home stays calm. Recomputed
   // automatically as history grows.
-  const hasRetroGaps = useMemo(() => hasMissedStrength(history, 3), [history]);
+  // User-customised week (per-device). Null when the user hasn't edited it →
+  // engine functions fall back to the default WEEK from programme.js. The
+  // strength-day → SESSIONS index map is derived from whichever week is
+  // active so a custom schedule (e.g. Mon-Wed cardio → strength Thu-Sat)
+  // still maps each strength weekday to the right A/B/C session.
+  const userWeek = useMemo(() => W.get() || WEEK, []);
+  const strengthDaySessions = useMemo(() => deriveStrengthDaySessions(userWeek), [userWeek]);
+  const hasRetroGaps = useMemo(() => hasMissedStrength(history, 3, { week: userWeek }), [history, userWeek]);
 
   // Seed on profile change: instant load from localStorage, background sync from blob
   useEffect(()=>{
@@ -1014,7 +1021,7 @@ const sProps={
   const dow      = new Date().getDay();
   const weekMap  = [6,0,1,2,3,4,5];
   const todayIdx = weekMap[dow];
-  const todaySessionIdx = STRENGTH_DAY_SESSIONS[todayIdx] ?? 0;
+  const todaySessionIdx = strengthDaySessions[todayIdx] ?? 0;
 
   // Actually rotate. Returns the new block so we can compute the diff.
   // History carries the last ROTATION_MEMORY_BLOCKS selections per slot, so a
@@ -1199,7 +1206,7 @@ const sProps={
   // fires once per retrospective submission.
   const handleSubmitRetro = (payload) => {
     if (!activeProfile || !retroDate) return;
-    const meta = sessionMetaForDate(retroDate);
+    const meta = sessionMetaForDate(retroDate, userWeek);
     if (!meta || meta.type !== "strength") return;
 
     const sessionDef = SESSIONS[meta.sessionIdx];
@@ -1471,12 +1478,12 @@ const sProps={
 
   return (
     <div style={{background:T.bg0,minHeight:"100vh",maxWidth:430,margin:"0 auto",fontFamily:T.sans,color:T.text1,WebkitFontSmoothing:"antialiased"}}>
-      {screen==="home"        && <HomeScreen rhythm={rhythm} profileName={activeProfile} onBegin={beginSession} onProfile={()=>setShowProfiles(true)} weekDone={weekDone} onMarkDayDone={handleMarkDayDone} programmeBlock={programmeBlock} weeksOnBlock={weeksOnBlock} onRotate={handleRotate} onResetProgramme={handleResetProgramme} onPerformance={handleOpenPerformance} historyCount={history.length} recoveryNudge={recoveryNudge} onDismissRecovery={()=>setRecoveryDismissed(true)} syncState={syncState} pendingDraft={pendingDraft} onResumeDraft={handleResumeDraft} onDiscardDraft={handleDiscardDraft} showBwCard={bwIsStale && !bwCardDismissed} onOpenBwEdit={()=>setBwEditOpen(true)} onDismissBwCard={()=>setBwCardDismissed(true)} deloadOffer={deloadOffer} onAcceptDeload={handleAcceptDeload} onDismissDeload={handleDismissDeload} hasRetroGaps={hasRetroGaps} onOpenRetroPicker={handleOpenRetroPicker} retroToast={retroToast} onDismissRetroToast={()=>setRetroToast(null)} pnStage={pnStage} pnBusy={pnBusy} pnError={pnError} pnSuccessToast={pnSuccessToast} onPnRegister={handleRegisterPasskeyFromHome} onPnSnooze={handleSnoozeNudge} onPnDismissToast={()=>setPnSuccessToast(false)}/>}
+      {screen==="home"        && <HomeScreen rhythm={rhythm} profileName={activeProfile} userWeek={userWeek} strengthDaySessions={strengthDaySessions} onBegin={beginSession} onProfile={()=>setShowProfiles(true)} weekDone={weekDone} onMarkDayDone={handleMarkDayDone} programmeBlock={programmeBlock} weeksOnBlock={weeksOnBlock} onRotate={handleRotate} onResetProgramme={handleResetProgramme} onPerformance={handleOpenPerformance} historyCount={history.length} recoveryNudge={recoveryNudge} onDismissRecovery={()=>setRecoveryDismissed(true)} syncState={syncState} pendingDraft={pendingDraft} onResumeDraft={handleResumeDraft} onDiscardDraft={handleDiscardDraft} showBwCard={bwIsStale && !bwCardDismissed} onOpenBwEdit={()=>setBwEditOpen(true)} onDismissBwCard={()=>setBwCardDismissed(true)} deloadOffer={deloadOffer} onAcceptDeload={handleAcceptDeload} onDismissDeload={handleDismissDeload} hasRetroGaps={hasRetroGaps} onOpenRetroPicker={handleOpenRetroPicker} retroToast={retroToast} onDismissRetroToast={()=>setRetroToast(null)} pnStage={pnStage} pnBusy={pnBusy} pnError={pnError} pnSuccessToast={pnSuccessToast} onPnRegister={handleRegisterPasskeyFromHome} onPnSnooze={handleSnoozeNudge} onPnDismissToast={()=>setPnSuccessToast(false)}/>}
       {screen==="readiness"   && <ReadinessScreen readiness={readiness} setReadiness={setReadiness} reason={readinessReason} setReason={setReadinessReason} onStart={handleReadinessStart}/>}
       {screen==="session"     && <ErrorBoundary><SessionScreen {...sProps}/></ErrorBoundary>}
-      {screen==="done"        && <ErrorBoundary><DoneScreen session={activeSession} profileName={activeProfile} workingWeights={workingWeights} onHome={()=>{ setShowDeloadComplete(false); reset(); }} deloadCompleted={showDeloadComplete}/></ErrorBoundary>}
+      {screen==="done"        && <ErrorBoundary><DoneScreen session={activeSession} profileName={activeProfile} workingWeights={workingWeights} userWeek={userWeek} onHome={()=>{ setShowDeloadComplete(false); reset(); }} deloadCompleted={showDeloadComplete}/></ErrorBoundary>}
       {screen==="performance" && <ErrorBoundary><PerformanceLab history={history} onBack={()=>setScreen("home")}/></ErrorBoundary>}
-      {screen==="retro"       && retroDate && <ErrorBoundary><RetrospectiveSessionSheet date={retroDate} bodyweight={bodyweight} workingWeights={workingWeights} workingReps={workingReps} onCancel={handleCancelRetro} onSubmit={handleSubmitRetro}/></ErrorBoundary>}
+      {screen==="retro"       && retroDate && <ErrorBoundary><RetrospectiveSessionSheet date={retroDate} bodyweight={bodyweight} workingWeights={workingWeights} workingReps={workingReps} userWeek={userWeek} onCancel={handleCancelRetro} onSubmit={handleSubmitRetro}/></ErrorBoundary>}
       {retroPickerOpen        && <RetroPickerSheet history={history} pendingDraft={pendingDraft} onPick={handlePickRetroDate} onClose={()=>setRetroPickerOpen(false)}/>}
       {rotationSummary        && <RotationSummaryModal summary={rotationSummary} onContinue={handleRotationContinue}/>}
       {showIosInstall         && <IosInstallOverlay onDismiss={()=>{ LS.set("forge:iosInstallDismissed", true); setShowIosInstall(false); }}/>}
@@ -2416,7 +2423,7 @@ function ProfileScreen({existing,current,onActivate,onCancel,bodyweight=null,bwE
 }
 
 // ─── Home ──────────────────────────────────��──────────────────────────────────
-function HomeScreen({rhythm,profileName,onBegin,onProfile,weekDone={},onMarkDayDone,programmeBlock,weeksOnBlock,onRotate,onResetProgramme,onPerformance,historyCount=0,recoveryNudge=null,onDismissRecovery,syncState="idle",pendingDraft=null,onResumeDraft,onDiscardDraft,showBwCard=false,onOpenBwEdit,onDismissBwCard,deloadOffer=null,onAcceptDeload,onDismissDeload,hasRetroGaps=false,onOpenRetroPicker,retroToast=null,onDismissRetroToast,pnStage="hidden",pnBusy=false,pnError=null,pnSuccessToast=false,onPnRegister,onPnSnooze,onPnDismissToast}){
+function HomeScreen({rhythm,profileName,userWeek,strengthDaySessions,onBegin,onProfile,weekDone={},onMarkDayDone,programmeBlock,weeksOnBlock,onRotate,onResetProgramme,onPerformance,historyCount=0,recoveryNudge=null,onDismissRecovery,syncState="idle",pendingDraft=null,onResumeDraft,onDiscardDraft,showBwCard=false,onOpenBwEdit,onDismissBwCard,deloadOffer=null,onAcceptDeload,onDismissDeload,hasRetroGaps=false,onOpenRetroPicker,retroToast=null,onDismissRetroToast,pnStage="hidden",pnBusy=false,pnError=null,pnSuccessToast=false,onPnRegister,onPnSnooze,onPnDismissToast}){
   // Two-tap reset confirmation: first tap arms, second tap commits, 5s timeout disarms.
   const [resetArmed, setResetArmed] = useState(false);
   const resetTimerRef = useRef(null);
@@ -2442,13 +2449,13 @@ function HomeScreen({rhythm,profileName,onBegin,onProfile,weekDone={},onMarkDayD
 
   const [viewIdx, setViewIdx] = useState(todayIdx);
 
-  const viewDay        = WEEK[viewIdx];
+  const viewDay        = userWeek[viewIdx];
   const cfg            = DAY_CONFIG[viewDay.type] || DAY_CONFIG.rest;
   const accent         = T[viewDay.type] || T.rest;
   const isViewingToday = viewIdx === todayIdx;
 
   // Resolve which session to preview for the viewed day (null for non-strength days)
-  const viewSessionIdx = STRENGTH_DAY_SESSIONS[viewIdx];
+  const viewSessionIdx = strengthDaySessions[viewIdx];
   const viewSession    = viewSessionIdx !== undefined ? SESSIONS[viewSessionIdx] : null;
 
   // Dynamic headline/sub for strength days
@@ -2513,7 +2520,7 @@ function HomeScreen({rhythm,profileName,onBegin,onProfile,weekDone={},onMarkDayD
       {/* Week strip — tappable */}
       <Fade d={60}>
         <div style={{padding:"28px 24px 0",display:"flex",gap:8}}>
-          {WEEK.map((d,i)=>{
+          {userWeek.map((d,i)=>{
             const a       = T[d.type];
             const isToday = i === todayIdx;
             const isView  = i === viewIdx;
@@ -3528,8 +3535,8 @@ function RetroPickerSheet({history, pendingDraft, onPick, onClose}){
 // the selected date. Auto-fill across cells in a row; tap any cell to override
 // via the existing ScrollDrum overlay. Skip toggle per exercise. One RPE
 // applied to all sets in an exercise.
-function RetrospectiveSessionSheet({date, bodyweight, workingWeights, workingReps, onCancel, onSubmit}){
-  const meta = useMemo(() => sessionMetaForDate(date), [date]);
+function RetrospectiveSessionSheet({date, bodyweight, workingWeights, workingReps, userWeek=WEEK, onCancel, onSubmit}){
+  const meta = useMemo(() => sessionMetaForDate(date, userWeek), [date, userWeek]);
   const sessionDef = meta?.type === "strength" ? SESSIONS[meta.sessionIdx] : null;
 
   // Flatten blocks into a single exercise list, but keep a back-reference to
@@ -3917,7 +3924,7 @@ const NEXT_DAY_MSG = {
   strength:"Strength session next. Load up.",
 };
 
-function DoneScreen({session,profileName,workingWeights,onHome,deloadCompleted=false}){
+function DoneScreen({session,profileName,workingWeights,userWeek=WEEK,onHome,deloadCompleted=false}){
   const nudges = session.blocks.filter(b=>b.type==="main").map(b=>{
     const base    = b.ex.weight;
     const current = workingWeights[b.ex.name] ?? base;
@@ -3932,7 +3939,7 @@ function DoneScreen({session,profileName,workingWeights,onHome,deloadCompleted=f
   const weekMap = [6,0,1,2,3,4,5];
   const todayIdx= weekMap[dow];
   const nextIdx = (todayIdx+1) % 7;
-  const nextType= WEEK[nextIdx]?.type ?? "rest";
+  const nextType= userWeek[nextIdx]?.type ?? "rest";
   const nextMsg = NEXT_DAY_MSG[nextType] ?? "";
 
   // Sync status for confirmation line

--- a/lib/programme.js
+++ b/lib/programme.js
@@ -19,8 +19,26 @@ export const WEEK = [
   { s:"S", label:"Rest",     type:"rest"     },
 ];
 
-// Maps WEEK index → SESSIONS index  (Mon=0, Wed=1, Fri=2)
+// Maps WEEK index → SESSIONS index  (Mon=0, Wed=1, Fri=2 for the default week).
+// For the user-editable week, derive at runtime via deriveStrengthDaySessions.
 export const STRENGTH_DAY_SESSIONS = { 0:0, 2:1, 4:2 };
+
+// Derive the strength-day → SESSIONS index mapping from any week config.
+// Walks the week in order; each `type: "strength"` slot consumes the next
+// session (0 → A, 1 → B, 2 → C). Extra strength days (4th, 5th) cycle back
+// to A → so users with a heavier week still get every default session covered.
+// Returns the same shape as STRENGTH_DAY_SESSIONS so callers are drop-in.
+export function deriveStrengthDaySessions(week = WEEK) {
+  const out = {};
+  let idx = 0;
+  for (let i = 0; i < (week?.length || 0); i++) {
+    if (week[i]?.type === "strength") {
+      out[i] = idx % SESSIONS.length;
+      idx++;
+    }
+  }
+  return out;
+}
 
 // ─── Three strength sessions ───────────────────────────────────────────────────
 // Pool[0] of each accessory slot is the programme default.
@@ -595,20 +613,21 @@ const JS_DAY_TO_WEEK_INDEX = [6, 0, 1, 2, 3, 4, 5];
 //
 // Pure function. No history or state lookups — calculation is purely from the
 // static WEEK + STRENGTH_DAY_SESSIONS rotation tables.
-export function sessionMetaForDate(dateStr) {
+export function sessionMetaForDate(dateStr, week = WEEK) {
   if (!dateStr || typeof dateStr !== "string") return null;
   const d = new Date(dateStr + "T12:00:00"); // noon-anchor avoids DST edge cases
   if (isNaN(d.getTime())) return null;
 
   const dow     = d.getDay();
   const weekIdx = JS_DAY_TO_WEEK_INDEX[dow];
-  const weekDay = WEEK[weekIdx];
+  const weekDay = week?.[weekIdx];
   if (!weekDay) return null;
 
   const dateLabel = d.toLocaleDateString("en-GB", { weekday: "short", day: "numeric", month: "short" });
 
   if (weekDay.type === "strength") {
-    const sessionIdx = STRENGTH_DAY_SESSIONS[weekIdx];
+    const strengthDaySessions = (week === WEEK) ? STRENGTH_DAY_SESSIONS : deriveStrengthDaySessions(week);
+    const sessionIdx = strengthDaySessions[weekIdx];
     const session    = SESSIONS[sessionIdx];
     return {
       type: "strength",
@@ -659,7 +678,7 @@ function localDateStr(d) {
 // Returns oldest first → newest first based on `order` param. Default newest first.
 //
 // Each row: { date, ...sessionMeta, logged: boolean, recordId: string|null }
-export function findRecentDays(history = [], daysBack = 3, { order = "desc" } = {}) {
+export function findRecentDays(history = [], daysBack = 3, { order = "desc", week = WEEK } = {}) {
   if (daysBack < 1) return [];
   const today    = new Date();
   today.setHours(0, 0, 0, 0);
@@ -679,7 +698,7 @@ export function findRecentDays(history = [], daysBack = 3, { order = "desc" } = 
     const d = new Date(today);
     d.setDate(d.getDate() - i);
     const dateStr = localDateStr(d);
-    const meta    = sessionMetaForDate(dateStr);
+    const meta    = sessionMetaForDate(dateStr, week);
     if (!meta) continue;
     rows.push({
       date: dateStr,
@@ -697,7 +716,7 @@ export function findRecentDays(history = [], daysBack = 3, { order = "desc" } = 
 // missing. Used by the home screen to decide whether to surface the
 // "Log past session" link at all — when there's nothing to fill, the link
 // stays hidden so home doesn't acquire chrome that isn't pulling its weight.
-export function hasMissedStrength(history = [], daysBack = 3) {
-  const rows = findRecentDays(history, daysBack);
+export function hasMissedStrength(history = [], daysBack = 3, { week = WEEK } = {}) {
+  const rows = findRecentDays(history, daysBack, { week });
   return rows.some(r => r.type === "strength" && !r.logged);
 }

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -204,6 +204,65 @@ export const PQ = {
 // ─── Programme block (rotation state) ────────────────────────────────────────
 // Shared across profiles on this device — one training block.
 // Synced to blob so it survives device switches.
+// ─── Weekly schedule (user-editable) ────────────────────────────────────────
+// Per-device weekly schedule — overrides the default WEEK from programme.js
+// when the user has customised it (e.g. cardio Mon-Wed → strength Thu-Sat).
+// Shared across profiles on this device (same pattern as programmeBlock).
+//
+// Storage shape (minimum): array of 7 `{type}` entries (Mon=0 ... Sun=6).
+// On read, W.get() normalises each entry to include `s` (day initial M/T/W…)
+// and `label` (the type's display name), so consumers always see the same
+// `{s, label, type}` shape as the default WEEK from programme.js. This keeps
+// the storage payload minimal while leaving display code unchanged.
+const VALID_WEEK_TYPES = new Set(["strength", "zone2", "cardio", "hiit", "rest"]);
+const POSITION_INITIAL = ["M", "T", "W", "T", "F", "S", "S"];
+const TYPE_LABEL = {
+  strength: "Strength",
+  zone2:    "Zone 2",
+  cardio:   "Cardio",
+  hiit:     "HIIT",
+  rest:     "Rest",
+};
+function isValidWeekConfig(w) {
+  return Array.isArray(w)
+    && w.length === 7
+    && w.every((d) => d && typeof d === "object" && VALID_WEEK_TYPES.has(d.type));
+}
+function normaliseWeek(week) {
+  return week.map((d, i) => ({
+    s:     d.s     || POSITION_INITIAL[i],
+    label: d.label || TYPE_LABEL[d.type] || "—",
+    type:  d.type,
+  }));
+}
+export const W = {
+  // Returns user-customised week (normalised to {s, label, type}), or null
+  // when none/invalid is stored. Callers fall back to the default WEEK from
+  // programme.js when this returns null.
+  get: () => {
+    const raw = LS.get("forge:weekConfig", null);
+    if (raw === null) return null;
+    if (!isValidWeekConfig(raw)) {
+      console.warn("W.get: invalid forge:weekConfig in localStorage — falling back to default");
+      return null;
+    }
+    return normaliseWeek(raw);
+  },
+  save: (week) => {
+    if (!isValidWeekConfig(week)) {
+      throw new Error("W.save: invalid week config — must be 7 entries of {type:<known>}");
+    }
+    // Persist normalised shape so saved data is self-describing on disk.
+    LS.set("forge:weekConfig", normaliseWeek(week));
+    return normaliseWeek(week);
+  },
+  // Clear the override → callers fall back to the default WEEK from programme.js.
+  reset: () => {
+    LS.remove("forge:weekConfig");
+    return null;
+  },
+};
+
 export const PB = {
   get: () => LS.get("forge:programmeBlock", {
     number:    1,

--- a/tests/programme.test.js
+++ b/tests/programme.test.js
@@ -17,10 +17,14 @@ import {
   SESSIONS,
   EXERCISE_POOLS,
   SWAP_DB,
+  WEEK,
+  STRENGTH_DAY_SESSIONS,
   findRecentDays,
   rotateAccessories,
   pushHistoryBlock,
   computeRotationStimulusDelta,
+  deriveStrengthDaySessions,
+  sessionMetaForDate,
   ROTATION_MEMORY_BLOCKS,
   MAIN_LIFT_FUNCTIONAL_EQUIVALENTS,
 } from "../lib/programme.js";
@@ -381,5 +385,77 @@ describe("MAIN_LIFT_FUNCTIONAL_EQUIVALENTS ↔ SWAP_DB alignment", () => {
         expect(swapNames.has(n), `${lift} SWAP_DB regressed: contains lighter ${n}`).toBe(false);
       }
     }
+  });
+});
+
+// ─── User-editable weekly schedule (plumbing) ──────────────────────────────
+describe("deriveStrengthDaySessions", () => {
+  it("default WEEK derives to {0:0, 2:1, 4:2} (Mon=A, Wed=B, Fri=C)", () => {
+    expect(deriveStrengthDaySessions(WEEK)).toEqual(STRENGTH_DAY_SESSIONS);
+  });
+
+  it("custom week with strength on Thu/Fri/Sat maps in order to A/B/C", () => {
+    const w = [
+      { type: "zone2" },     // Mon
+      { type: "cardio" },    // Tue
+      { type: "hiit" },      // Wed
+      { type: "strength" },  // Thu
+      { type: "strength" },  // Fri
+      { type: "strength" },  // Sat
+      { type: "rest" },      // Sun
+    ];
+    expect(deriveStrengthDaySessions(w)).toEqual({ 3: 0, 4: 1, 5: 2 });
+  });
+
+  it("a 4th strength day cycles back to A (so heavy weeks still cover every session)", () => {
+    const w = [
+      { type: "strength" }, { type: "strength" }, { type: "strength" }, { type: "strength" },
+      { type: "rest" }, { type: "rest" }, { type: "rest" },
+    ];
+    expect(deriveStrengthDaySessions(w)).toEqual({ 0: 0, 1: 1, 2: 2, 3: 0 });
+  });
+
+  it("returns {} when no strength days", () => {
+    const w = [
+      { type: "zone2" }, { type: "cardio" }, { type: "rest" }, { type: "rest" },
+      { type: "rest" }, { type: "rest" }, { type: "rest" },
+    ];
+    expect(deriveStrengthDaySessions(w)).toEqual({});
+  });
+
+  it("guards against null / empty array (returns {})", () => {
+    expect(deriveStrengthDaySessions(null)).toEqual({});
+    expect(deriveStrengthDaySessions([])).toEqual({});
+  });
+
+  it("called with no argument defaults to the canonical WEEK", () => {
+    // Convenience default — same shape as the exported STRENGTH_DAY_SESSIONS.
+    expect(deriveStrengthDaySessions()).toEqual(STRENGTH_DAY_SESSIONS);
+  });
+});
+
+describe("sessionMetaForDate — custom week", () => {
+  // Pick a known Monday so the math is unambiguous in JS_DAY_TO_WEEK_INDEX.
+  const monday = "2026-05-25"; // Monday
+  const friday = "2026-05-29"; // Friday
+
+  it("default week: Mon → Strength A, Fri → Strength C (unchanged behaviour)", () => {
+    expect(sessionMetaForDate(monday)?.sessionName).toBe("Strength A");
+    expect(sessionMetaForDate(friday)?.sessionName).toBe("Strength C");
+  });
+
+  it("shifted week: Mon=Zone 2, Fri=Strength A → engine reads from the supplied week", () => {
+    const w = [
+      { type: "zone2" },     // Mon
+      { type: "cardio" },    // Tue
+      { type: "rest" },      // Wed
+      { type: "rest" },      // Thu
+      { type: "strength" },  // Fri  ← first strength day → A
+      { type: "strength" },  // Sat  ← B
+      { type: "strength" },  // Sun  ← C
+    ];
+    expect(sessionMetaForDate(monday, w)?.type).toBe("zone2");
+    expect(sessionMetaForDate(friday, w)?.type).toBe("strength");
+    expect(sessionMetaForDate(friday, w)?.sessionName).toBe("Strength A");
   });
 });


### PR DESCRIPTION
## Summary

User refinement-list **#11**, part **1 of 2**. Pure backward-compatible refactor that prepares the engine to read a user-customised weekly schedule. **No user-visible change in this PR** — the UI editor follows in PR-B.

The goal: after this lands, swapping the default `WEEK` for a user-edited one is a one-line change anywhere that calls `W.get()`. All the plumbing is in place; only the editor surface remains.

## What's user-editable here

The use case (from the user discussion): *"Some folks can't train at the gym on Monday, they want cardio Mon–Wed then back-to-back strength workouts without having to 'log missed workouts'."*

Each weekday gets a type — `strength` / `zone2` / `cardio` / `hiit` / `rest`. The strength-day → A/B/C mapping is **derived in order** from the week: walk through, each `strength` slot consumes the next session (0 → A, 1 → B, 2 → C, cycling). A heavy week with 4 strength days still covers every session.

## Engine

**`lib/programme.js`**
- `sessionMetaForDate(dateStr, week = WEEK)` — accepts the user's week.
- `findRecentDays(history, daysBack, { order, week })` — accepts the user's week.
- `hasMissedStrength(history, daysBack, { week })` — accepts the user's week.
- **New `deriveStrengthDaySessions(week)`** helper. Default WEEK still derives to `{0:0, 2:1, 4:2}` so existing behaviour is bit-identical.

## Storage

**New `W` module in `lib/storage.js`**, parallel to `PB`:

```js
W.get()         // → normalised week (or null if nothing saved)
W.save(week)    // → validates + persists
W.reset()       // → clears override; callers fall back to default WEEK
```

- Stored at `forge:weekConfig`. Per-device, same scope as `programmeBlock`. Cross-device sync via the profile blob is deferred — easy follow-up if user demand surfaces.
- **Strict validation** on save (7 entries × known type), corrupt values warn-and-fall-back on read.
- **`W.get()` normalises** each entry to include `s` (day initial) and `label` (display name) so consumers see the same `{s, label, type}` shape as the default WEEK — display code is unchanged.

## ForgeApp.jsx

Computes `userWeek = W.get() || WEEK` once on mount and threads it (plus the derived `strengthDaySessions`) through every consumer:

- `hasMissedStrength` (retro detection)
- `todaySessionIdx` (today's session resolution)
- `sessionMetaForDate` (retro picker)
- `<HomeScreen>` (week strip + viewed day + viewed session)
- `<RetrospectiveSessionSheet>`
- `<DoneScreen>` ("what's next" message)

Default-parameter fallback to `WEEK` on the subcomponent signatures keeps each downstream component working independent of the parent's choice to pass `userWeek` — safe to extract / reuse.

## Tests (+8)

- `deriveStrengthDaySessions`: default-WEEK invariant, custom Thu/Fri/Sat layout, 4th-strength-day cycle-back to A, no-strength-days returns `{}`, null/empty guards, undefined defaults to canonical `STRENGTH_DAY_SESSIONS`.
- `sessionMetaForDate`: default-week behaviour unchanged (Mon=A, Fri=C), shifted-week behaviour reads from the supplied week (Mon→Zone 2, Fri→Strength A).

## Test plan

- [x] `npm test` → 247/247.
- [x] `npm run lint` → clean.
- [x] `npx next build` → clean.
- [x] `npm run audit:volume` → no flags (static programme unchanged).
- [ ] On preview: home screen still shows Mon/Wed/Fri as strength days (no week saved yet → defaults).

## Part of #11 series

- **PR-A (this):** Storage + engine plumbing.
- **PR-B (next):** Week editor UI — small sheet with 7 day-type selectors, save → `W.save()` → home screen reflows.
- *(Possible PR-C):* cross-device blob sync of `forge:weekConfig`, if signal warrants.

## Refinement-list status

- ✅ #2, #5, #6, #9, #10 — shipped.
- 🔄 #11 PR-A — this PR.
- ⏭ #11 PR-B — week editor UI.
- ⏭ #3 + #7 — service worker + Vercel cache header audit (low priority, deferrable).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gucgxvub2JW5XT1q9dhU8f)_