### PR TITLE
Cache headers: long-lived PWA icons + manifest

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,5 +5,19 @@
       "path": "/api/cron/cleanup",
       "schedule": "0 3 * * *"
     }
+  ],
+  "headers": [
+    {
+      "source": "/icon-:size.png",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=86400, stale-while-revalidate=604800" }
+      ]
+    },
+    {
+      "source": "/manifest.json",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=3600" }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Summary

User refinement-list **#7** — Vercel cache header audit. 10-minute check, one small real win.

## Audit results

| Surface | Current | Verdict |
|---|---|---|
| `_next/static/*` bundles | Next auto-applies `Cache-Control: public, max-age=31536000, immutable` (content-hashed filenames) | ✅ correct, no action |
| API routes (`/api/sync`, `/api/auth/*`, `/api/cron/*`) | No explicit headers; Next 16 defaults `route.js` to dynamic / `no-store` | ✅ correct, no action |
| **Static `public/*` (PWA icons, manifest)** | **No cache headers** — browsers revalidate every request | ⚠ **fix this** |

## Fix

Two `vercel.json` header rules:

```json
"headers": [
  {
    "source": "/icon-:size.png",
    "headers": [
      { "key": "Cache-Control", "value": "public, max-age=86400, stale-while-revalidate=604800" }
    ]
  },
  {
    "source": "/manifest.json",
    "headers": [
      { "key": "Cache-Control", "value": "public, max-age=3600" }
    ]
  }
]
```

**Rationale:**
- **Icons** change only on rebrand. 1-day fresh cache + 7-day `stale-while-revalidate` gives instant load on revisits and silent background refresh if updated.
- **Manifest** changes when we tweak app name/colours. 1-hour cache is conservative but lets users pick up changes promptly.

## What I deliberately didn't do

- **No headers on API routes.** Next 16's App Router already serves them with `no-store` because they're dynamic — explicit headers would be churn without benefit, and a wrong value could break the auth/sync flow.
- **No headers on `_next/static/*`.** Already optimal — content-hashed paths get immutable headers from the framework automatically.

## Test plan

- [x] `vercel.json` validates as JSON.
- [x] `npm test` → 247/247.
- [x] `npx next build` → clean.
- [ ] On preview: open DevTools → Network tab → reload twice → confirm `/icon-192.png` and `/manifest.json` come back `(disk cache)` instead of a fresh 200 with revalidation.

## Refinement-list status

- ✅ #2, #5, #6, #7, #9, #10, #11 — all shipped after this merges.
- ⏭ **#3 Service worker** — last item; explicit Tier 4 (1–2 days work).

Up next: Tier 4 **#11 ARIA pass** on modals + drum picker (1–2 hours, defensive polish).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gucgxvub2JW5XT1q9dhU8f)_