### PR TITLE
Licensing: AGPL-3.0 + commercial dual-licence path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 Items in flight on `main` but not yet tagged. Tagged releases will move them into a dated section below.
 
+### Changed
+- **Licensing clarified — AGPL-3.0 + commercial dual-licence path.** Added an explicit copyright preamble to `LICENSE`, set `"license": "AGPL-3.0-only"` in `package.json`, and added `LICENSING.md` documenting the dual-licence terms. The underlying AGPL-3.0 text is unchanged — what changed is *attribution* (copyright is now explicitly held by wondabrar) and *commercial reservation* (a paid licence is available for use cases AGPL-3.0 doesn't cover: closed-source SaaS, white-label, proprietary integrations).
+
 ---
 
 ## Tier 2 — programme intelligence

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,22 @@
+Forge — evidence-based, autoregulated strength programme.
+
+Copyright (c) 2024–2026 wondabrar (abrar.a@outlook.com). All rights reserved
+except as granted by the GNU Affero General Public License, version 3, set
+out in full below.
+
+In short: you may use, study, modify, and self-host Forge under the AGPL-3.0
+terms. If you run a modified version as a network service, you must publish
+your full source under AGPL-3.0 as well.
+
+Commercial licenses (non-AGPL terms, e.g. closed-source SaaS, white-label,
+proprietary integrations) are available — see LICENSING.md or contact
+abrar.a@outlook.com.
+
+The unmodified GNU AGPL-3.0 license text follows. The terms below are the
+binding legal grant; the summary above is informative only.
+
+────────────────────────────────────────────────────────────────────────────
+
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,48 @@
+# Licensing
+
+Forge is dual-licensed.
+
+## Default: AGPL-3.0
+
+Forge is available under the [GNU Affero General Public License, version 3](./LICENSE) at no cost. Under AGPL-3.0 you may:
+
+- Use, study, modify, and self-host Forge for any purpose, including commercial use.
+- Distribute the source or your modified versions.
+
+**You must, in return:**
+
+- Keep the AGPL-3.0 license and copyright notices intact in any distribution.
+- If you run a modified version of Forge as a network-accessible service (e.g. a fitness app or web product that users interact with remotely), **publish your full modified source under AGPL-3.0** for those users.
+
+This is the AGPL's network clause — the term most people mean when they say "AGPL." It exists to prevent the SaaS loophole MIT and Apache leave open.
+
+## Commercial license (non-AGPL)
+
+If AGPL-3.0 doesn't fit your use case — for example:
+
+- You want to run a closed-source SaaS built on Forge without publishing your modifications.
+- You're a gym chain or fitness brand wanting a white-label deployment.
+- You want to integrate Forge's engine into a proprietary product.
+- Your organisation's policy disallows AGPL'd dependencies.
+
+…a separate, paid commercial license is available. Terms are negotiated case-by-case (per-seat, revenue share, or flat fee depending on scope).
+
+**Contact:** `abrar.a@outlook.com`
+
+A commercial license grants you the same code under terms that do not require open-sourcing your derivative work. The default AGPL-3.0 release remains available to everyone else.
+
+## What is "Forge"?
+
+For licensing purposes, "Forge" refers to the contents of this repository (`wondabrar/project-forge`) — the source code, the programme design (`lib/programme.js` `SESSIONS` / `EXERCISE_POOLS`), the curated exercise anatomy dataset (`lib/exercise-anatomy.js`), the rotation and progression engines, the analytics layer, and the design tokens. All of these are covered by the same dual-license terms.
+
+## Quick FAQ
+
+**Can I fork Forge for personal use?** Yes — AGPL-3.0 permits any personal, educational, or self-hosted use.
+
+**Can I run an AGPL-licensed Forge as a service for my own gym?** Yes, as long as you publish your modifications back to your users under AGPL-3.0.
+
+**Can I take Forge, close-source it, and ship it as a paid product?** No — that requires a commercial license.
+
+**Can I copy the programme design into a different app?** The programme content (SESSIONS / pools / anatomy weights / volume targets) is part of "Forge" for licensing purposes — it's also covered. Treat it like the code.
+
+**Why AGPL and not MIT?** MIT lets competitors take the engine into a closed product. AGPL closes that loophole. The dual-license offer above keeps the commercial path open without giving the work away.

--- a/README.md
+++ b/README.md
@@ -177,8 +177,9 @@ When you add a new SESSIONS exercise, the pool/anatomy/canonical-name invariants
 
 - **README** — this file: what Forge is, how to run it, design principles.
 - **CHANGELOG** — [CHANGELOG.md](./CHANGELOG.md): what changed and why, newest first.
+- **Licensing** — [LICENSING.md](./LICENSING.md): AGPL-3.0 default + commercial-licence path.
 - **Code of Conduct** — [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md).
 
 ## License
 
-See [LICENSE](./LICENSE).
+Forge is dual-licensed. The default release is **AGPL-3.0** — see [LICENSE](./LICENSE) for the full terms and [LICENSING.md](./LICENSING.md) for what that means in practice. Commercial licences for use cases AGPL-3.0 doesn't cover (closed-source SaaS, white-label, proprietary integrations) are available — contact `abrar.a@outlook.com`.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "project-forge",
   "version": "0.3.0",
   "private": true,
+  "license": "AGPL-3.0-only",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Summary

Licensing housekeeping per the in-thread discussion. Project IP now properly attributed and the commercial-licence path is unlocked for the day someone reaches out wanting non-AGPL terms (closed-source SaaS, white-label, gym-chain integration). **Zero behavioural change** — this is paperwork that costs nothing today and pays in optionality the day a "10k-user milestone" conversation actually happens.

## What changed

| File | Change |
|---|---|
| **LICENSE** | Prepended a project-specific preamble before the standard AGPL-3.0 text. Adds the copyright line (`Copyright (c) 2024–2026 wondabrar`), a plain-language summary of the AGPL terms, and an explicit reservation of commercial licensing rights. **The underlying AGPL-3.0 grant text is unchanged** and remains the binding legal terms. |
| **package.json** | Set `"license": "AGPL-3.0-only"` (the field was missing — minor hygiene). |
| **LICENSING.md** | New file. Explains the dual-licence model in plain English, defines "Forge" for licensing purposes (code + programme design + curated anatomy), and lists the use cases that warrant a commercial conversation. Contact = `abrar.a@outlook.com`. |
| **README.md** | License section rewritten to reflect the dual-licence model + link `LICENSING.md`. Documentation index updated. |
| **CHANGELOG.md** | Unreleased entry recording the licensing clarification. |

## What this gets you

- **Today:** AGPL-3.0 still applies as the default release. Forks must publish source if they run a modified Forge as a service. No competitor can lift the engine + audit + anatomy into a closed product.
- **The day someone asks:** a paid commercial licence is available. Terms negotiated per-deal (per-seat, revenue share, or flat fee). The default AGPL-3.0 release remains available to everyone else.

## Why AGPL stays the default (vs MIT or BSL)

- The programme design + volume audit + rotation engine + curated anatomy is **real IP**. AGPL closes the SaaS loophole MIT/Apache leave open.
- Dual-licence offer (rather than switching to BSL) keeps the open-source signalling intact while preserving the commercial path. Pattern used by early MongoDB and Sentry.

## Test plan

- [x] `package.json` is valid JSON with the new `license` field.
- [x] `LICENSE` preamble renders sensibly; the GPL text below it is byte-identical to the original.
- [x] `npm test` → 247/247 (no code touched).
- [x] `npm run lint` → clean.
- [x] `npx next build` → clean.
- [ ] On GitHub: confirm the repo page now displays `AGPL-3.0` as the license badge (GitHub picks this up from `LICENSE` + `package.json`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gucgxvub2JW5XT1q9dhU8f)_