### PR TITLE
Service worker — PR-A: registration scaffold (no caching)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 Items in flight on `main` but not yet tagged. Tagged releases will move them into a dated section below.
 
+### Added
+- **Service-worker scaffold (PR-A of N).** Wires up the SW lifecycle — `public/sw.js` installs and activates, `<ServiceWorkerRegistrar/>` registers it from the layout. No fetch interception, no caching yet — zero behavioural change. Foundation for the incremental offline-PWA work (app-shell precache → API strategy → IndexedDB session-log queue → background sync → update prompt). Escape hatch: `?nosw=1` on any URL unregisters all SWs + clears caches.
+
 ### Changed
 - **Licensing clarified — AGPL-3.0 + commercial dual-licence path.** Added an explicit copyright preamble to `LICENSE`, set `"license": "AGPL-3.0-only"` in `package.json`, and added `LICENSING.md` documenting the dual-licence terms. The underlying AGPL-3.0 text is unchanged — what changed is *attribution* (copyright is now explicitly held by wondabrar) and *commercial reservation* (a paid licence is available for use cases AGPL-3.0 doesn't cover: closed-source SaaS, white-label, proprietary integrations).
 

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -3,6 +3,7 @@ import { Fraunces, DM_Sans } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import ErrorBoundary from "@/components/ErrorBoundary";
+import ServiceWorkerRegistrar from "@/components/ServiceWorkerRegistrar";
 
 const fraunces = Fraunces({
   subsets: ["latin"],
@@ -52,6 +53,7 @@ export default function RootLayout({ children }) {
         <link rel="apple-touch-icon" href="/icon-192.png" />
       </head>
       <body>
+        <ServiceWorkerRegistrar />
         <ErrorBoundary>
           {children}
         </ErrorBoundary>

--- a/components/ServiceWorkerRegistrar.jsx
+++ b/components/ServiceWorkerRegistrar.jsx
@@ -1,0 +1,49 @@
+"use client";
+
+// Service-worker registration boundary. Client-side because the SW API only
+// exists in the browser. Renders nothing visible; lives once in app/layout.
+//
+// Escape hatch: append `?nosw=1` to any URL to unregister all service
+// workers + clear caches. Useful while iterating, and as a panic button if
+// a future SW deploy gets stuck on a user's device.
+
+import { useEffect } from "react";
+
+const SW_PATH = "/sw.js";
+
+export default function ServiceWorkerRegistrar() {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!("serviceWorker" in navigator)) return;
+
+    // Escape hatch — runs BEFORE any registration attempt so it can clear a
+    // stuck SW even on the first paint after the kill switch is appended.
+    if (new URLSearchParams(window.location.search).has("nosw")) {
+      navigator.serviceWorker.getRegistrations()
+        .then((regs) => Promise.all(regs.map((r) => r.unregister())))
+        .then(() => {
+          if (typeof caches !== "undefined") {
+            return caches.keys().then((keys) => Promise.all(keys.map((k) => caches.delete(k))));
+          }
+        })
+        .then(() => console.log("[sw] unregistered all + caches cleared (?nosw=1)"))
+        .catch((err) => console.warn("[sw] unregister failed:", err));
+      return;
+    }
+
+    navigator.serviceWorker
+      .register(SW_PATH, { scope: "/" })
+      .then((reg) => {
+        if (process.env.NODE_ENV !== "production") {
+          console.log("[sw] registered, scope:", reg.scope);
+        }
+      })
+      .catch((err) => {
+        // Registration failure is non-fatal — the app still works without
+        // the SW. Surface it in the console for diagnostics.
+        console.warn("[sw] registration failed:", err);
+      });
+  }, []);
+
+  return null;
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,30 @@
+// Forge service worker — PR-A scaffold.
+//
+// This is intentionally MINIMAL: it installs and activates so the SW
+// lifecycle is wired up, but it does NOT register a `fetch` event handler,
+// so it does not intercept any requests yet. The app behaves identically
+// to a no-SW build. Future PRs layer caching, IndexedDB queueing, and
+// background sync on top of this foundation.
+//
+// Versioning: bump SW_VERSION on every meaningful change. The activate
+// handler currently does nothing with it, but cache-prefixing future
+// stores by version is how we'll handle clean upgrades.
+
+const SW_VERSION = "0.1.0-scaffold";
+
+self.addEventListener("install", () => {
+  // skipWaiting so a freshly-installed SW takes control immediately on
+  // first deploy, rather than waiting for every tab to close.
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  // clients.claim() makes the SW control all open tabs immediately on
+  // activation. Without it, the SW only controls tabs opened AFTER
+  // activation, which makes incremental work harder to verify.
+  event.waitUntil(self.clients.claim());
+});
+
+// NO fetch handler yet. The SW is installed and active, but every fetch
+// goes directly to the network — same as before. PR-B adds the first
+// caching strategy (app-shell precache).


### PR DESCRIPTION
## Summary

Starts the incremental offline-PWA work from refinement-list **#3** / Tier 4 **#10**. This PR is **pure plumbing** — wires up the service-worker lifecycle so future PRs can layer caching on top without simultaneously debugging registration issues.

**Zero behavioural change for users today.** The SW installs and activates, but does not intercept any fetch requests. Every URL still goes straight to the network exactly as before. The point of this PR is to land the registration plumbing cleanly so the next PR is *just* about caching strategy.

## What's in this PR

| File | What |
|---|---|
| `public/sw.js` | Minimal service worker. `install` calls `skipWaiting()`; `activate` calls `clients.claim()`. **No `fetch` handler** — passes through. Versioned via `SW_VERSION` constant so future cache prefixing can use it. |
| `components/ServiceWorkerRegistrar.jsx` | Client-side registrar mounted once in `app/layout.jsx`. Registers `/sw.js` at scope `/`. Registration failures are caught and logged — non-fatal. |
| `app/layout.jsx` | Mounts `<ServiceWorkerRegistrar/>` in `<body>`. |
| `CHANGELOG.md` | New "Added" entry describing the scaffold + roadmap for follow-up PRs. |

## Escape hatch

Append `?nosw=1` to any URL → the registrar **unregisters all SWs** and **clears all caches** instead of registering. Belt-and-braces for the day a future deploy gets stuck on someone's device.

```
https://theforged.fit/?nosw=1   → kills the SW + caches, reloads clean
```

## Roadmap (next PRs)

| PR | Scope |
|---|---|
| **A (this)** | Registration scaffold — zero behavioural change. |
| B | App-shell precaching (`_next/static/*`, manifest, icons). |
| C | Runtime caching strategy (network-first HTML, cache-first assets, network-only API). |
| D | IndexedDB queue for offline session logs. |
| E | Background-sync flush on reconnect. |
| F | Update-prompt UI when a new SW activates. |

Each PR is independently shippable and revertible. If anything goes wrong at any stage, the `?nosw=1` switch + reverting the offending PR returns the app to known-good behaviour.

## Test plan

- [x] `npm test` → 247/247.
- [x] `npm run lint` → clean.
- [x] `npx next build` → clean (`sw.js` is in `public/` so Next serves it unmodified at `/sw.js`, scope `/`).
- [ ] On preview: DevTools → Application → Service Workers — confirm `sw.js` shows as activated, scope `/`. No fetch entries are intercepted (still network).
- [ ] Append `?nosw=1` → confirm console logs `[sw] unregistered all + caches cleared` and the Service Workers list goes empty.

## Status

- ✅ Refinement #3 — service worker — **now in flight (PR-A)**.
- Last remaining items from the doc + refinement list are now genuinely Tier 4 / signal-gated (Lighthouse-after-SW, install-prompt return-rate data, Tier 3 demand validation, opportunistic extractions).
