### PR TITLE
Service worker — PR-B: app-shell precache + runtime caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 Items in flight on `main` but not yet tagged. Tagged releases will move them into a dated section below.
 
 ### Added
+- **Service-worker app-shell cache (PR-B of N).** The SW now precaches the small static set (manifest + icons) at install, and applies per-path runtime caching: cache-first for `/_next/static/*` (immutable, content-hashed) and root binary assets (icons / fonts), network-first with cache fallback for HTML / navigation (online users get fresh, offline users get the last cached shell), network-only for `/api/*` (auth + sync must never see stale responses). Cache versioning via `SW_VERSION` — `activate` cleans up older `forge-*` caches automatically.
 - **Service-worker scaffold (PR-A of N).** Wires up the SW lifecycle — `public/sw.js` installs and activates, `<ServiceWorkerRegistrar/>` registers it from the layout. No fetch interception, no caching yet — zero behavioural change. Foundation for the incremental offline-PWA work (app-shell precache → API strategy → IndexedDB session-log queue → background sync → update prompt). Escape hatch: `?nosw=1` on any URL unregisters all SWs + clears caches.
 
 ### Changed

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,30 +1,131 @@
-// Forge service worker — PR-A scaffold.
+// Forge service worker — PR-B: app-shell precache + runtime caching.
 //
-// This is intentionally MINIMAL: it installs and activates so the SW
-// lifecycle is wired up, but it does NOT register a `fetch` event handler,
-// so it does not intercept any requests yet. The app behaves identically
-// to a no-SW build. Future PRs layer caching, IndexedDB queueing, and
-// background sync on top of this foundation.
+// What this PR adds on top of PR-A's scaffold:
+//   - Precache the tiny set of always-needed static assets at install
+//     (manifest.json + the two icons).
+//   - Cache-first for /_next/static/* (content-hashed, immutable).
+//   - Cache-first for binary static assets at the root (.png, .ico, fonts).
+//   - Network-first with cache fallback for HTML / navigation requests, so
+//     the app shell still loads on a flaky gym wifi.
+//   - Network-only for /api/* — auth/sync must never see stale responses.
+//   - Cache versioning + cleanup of stale forge-* caches on activate.
 //
-// Versioning: bump SW_VERSION on every meaningful change. The activate
-// handler currently does nothing with it, but cache-prefixing future
-// stores by version is how we'll handle clean upgrades.
+// What this PR DOES NOT do (future PRs):
+//   - IndexedDB queue for offline session logs (PR-D).
+//   - Background-sync flush on reconnect (PR-E).
+//   - Update-prompt UI when a new SW activates (PR-F).
+//
+// Bump SW_VERSION on every meaningful change so the activate handler cleans
+// up older caches. Old caches are deleted by prefix match on every activate.
 
-const SW_VERSION = "0.1.0-scaffold";
+const SW_VERSION  = "0.2.0-shell-cache";
+const STATIC_CACHE = `forge-static-${SW_VERSION}`;
+const HTML_CACHE   = `forge-html-${SW_VERSION}`;
 
-self.addEventListener("install", () => {
-  // skipWaiting so a freshly-installed SW takes control immediately on
-  // first deploy, rather than waiting for every tab to close.
+// Precache list — must stay tiny. Anything else is added at runtime.
+const PRECACHE_URLS = [
+  "/manifest.json",
+  "/icon-192.png",
+  "/icon-512.png",
+];
+
+self.addEventListener("install", (event) => {
   self.skipWaiting();
+  event.waitUntil(
+    caches.open(STATIC_CACHE)
+      .then((cache) => cache.addAll(PRECACHE_URLS))
+      .catch((err) => {
+        // Don't block install if a precache asset 404s on this deploy —
+        // runtime caching will still pick it up on first request.
+        console.warn("[sw] precache failed:", err);
+      }),
+  );
 });
 
 self.addEventListener("activate", (event) => {
-  // clients.claim() makes the SW control all open tabs immediately on
-  // activation. Without it, the SW only controls tabs opened AFTER
-  // activation, which makes incremental work harder to verify.
-  event.waitUntil(self.clients.claim());
+  event.waitUntil((async () => {
+    const keys = await caches.keys();
+    const stale = keys.filter((k) => k.startsWith("forge-") && k !== STATIC_CACHE && k !== HTML_CACHE);
+    await Promise.all(stale.map((k) => caches.delete(k)));
+    await self.clients.claim();
+  })());
 });
 
-// NO fetch handler yet. The SW is installed and active, but every fetch
-// goes directly to the network — same as before. PR-B adds the first
-// caching strategy (app-shell precache).
+// ─── Strategy: cache-first ─────────────────────────────────────────────────
+// Use for immutable assets (content-hashed bundles, icons). Returns cache
+// hit immediately; populates cache on miss; falls through to network error
+// if both cache and network fail.
+async function cacheFirst(req, cacheName) {
+  const cache  = await caches.open(cacheName);
+  const cached = await cache.match(req);
+  if (cached) return cached;
+  const res = await fetch(req);
+  if (res.ok) {
+    // Clone before consuming — Response bodies are single-use.
+    cache.put(req, res.clone()).catch(() => { /* quota errors are non-fatal */ });
+  }
+  return res;
+}
+
+// ─── Strategy: network-first with cache fallback ───────────────────────────
+// Use for HTML / navigation. Online users always get the freshest shell;
+// offline users get the last-cached version so the PWA still opens at the
+// gym when wifi is flaky.
+async function networkFirst(req, cacheName) {
+  const cache = await caches.open(cacheName);
+  try {
+    const res = await fetch(req);
+    if (res.ok) {
+      cache.put(req, res.clone()).catch(() => { /* quota errors are non-fatal */ });
+    }
+    return res;
+  } catch (err) {
+    const cached = await cache.match(req);
+    if (cached) return cached;
+    throw err;
+  }
+}
+
+// ─── Fetch router ──────────────────────────────────────────────────────────
+self.addEventListener("fetch", (event) => {
+  const req = event.request;
+
+  // Only handle GET — POST/PUT/DELETE go straight to network.
+  if (req.method !== "GET") return;
+
+  const url = new URL(req.url);
+
+  // Only handle same-origin — cross-origin (Vercel blob, analytics, etc.)
+  // is left to the browser cache.
+  if (url.origin !== self.location.origin) return;
+
+  // API routes: never cache. Auth + sync must always see fresh server state.
+  if (url.pathname.startsWith("/api/")) return;
+
+  // Content-hashed Next bundles: cache-first, immutable.
+  if (url.pathname.startsWith("/_next/static/")) {
+    event.respondWith(cacheFirst(req, STATIC_CACHE));
+    return;
+  }
+
+  // Root-level static binaries (icons, favicon, fonts). Path-based test
+  // covers PWA assets that aren't fingerprinted.
+  if (/\.(png|jpe?g|svg|webp|gif|ico|woff2?|otf|ttf)$/i.test(url.pathname)) {
+    event.respondWith(cacheFirst(req, STATIC_CACHE));
+    return;
+  }
+
+  // Manifest: cache-first so PWA installability survives offline.
+  if (url.pathname === "/manifest.json") {
+    event.respondWith(cacheFirst(req, STATIC_CACHE));
+    return;
+  }
+
+  // HTML / navigation: network-first.
+  if (req.mode === "navigate" || (req.headers.get("accept") || "").includes("text/html")) {
+    event.respondWith(networkFirst(req, HTML_CACHE));
+    return;
+  }
+
+  // Anything else (Next data fetches, server actions, etc.) — pass through.
+});


### PR DESCRIPTION
## Summary

Layers caching onto PR-A's lifecycle scaffold. After this merges, the app shell loads from cache on a flaky gym wifi or a full offline reload, and hashed bundles serve instantly from cache instead of revalidating on every navigation.

**Behaviour change is GET-only** and falls back to network on every miss. **No POST/PUT/DELETE is touched**, so auth + sync flows are bit-identical. **`/api/*` is network-only** — auth/sync responses never come from cache.

If anything goes sideways: `?nosw=1` (from PR-A) still kills the SW + all caches in one tap.

## Strategy router (per-path)

| Path pattern | Strategy | Why |
|---|---|---|
| `/_next/static/*` | **cache-first** | Content-hashed, immutable — perfect cache candidate |
| `*.png` / `*.jpg` / `*.woff2` / fonts at root | **cache-first** | Root PWA icons + bundled font files |
| `/manifest.json` | **cache-first** | PWA installability survives offline |
| HTML / `req.mode === "navigate"` | **network-first → cache fallback** | Online users always get fresh shell; offline gets last good one |
| `/api/*` | **network-only** | Auth + sync must never see stale state |
| Everything else | **pass-through** | Next data fetches, server actions, etc. |
| Cross-origin | **pass-through** | Vercel blob, analytics — browser cache handles |

## Precache at install

The tiny set that's always needed and never changes per-deploy in any meaningful way:

```js
const PRECACHE_URLS = [
  "/manifest.json",
  "/icon-192.png",
  "/icon-512.png",
];
```

Precache failure is logged + non-fatal — runtime caching picks them up on first request anyway.

## Cache versioning

Two caches, both versioned by `SW_VERSION`:

- `forge-static-<version>` — precached + cache-first runtime hits
- `forge-html-<version>` — network-first HTML responses

On `activate`, every `forge-*` cache key that *doesn't* match the current version is deleted. So bumping `SW_VERSION` on any future PR-C/D/E automatically evicts the old shell.

## Out of scope (future PRs)

- **PR-D:** IndexedDB queue for offline session logs.
- **PR-E:** Background-sync flush on reconnect.
- **PR-F:** Update-prompt UI when a new SW activates.

(PR-C from the original roadmap is folded into this one — the runtime strategy is small enough to ship alongside the precache.)

## Test plan

- [x] `node --check public/sw.js` → parses cleanly.
- [x] `npm test` → 247/247.
- [x] `npm run lint` → clean.
- [x] `npx next build` → clean.
- [ ] On the preview deploy:
  - DevTools → Application → Service Workers → confirm `0.2.0-shell-cache` activated, scope `/`.
  - Application → Cache Storage → `forge-static-0.2.0-shell-cache` contains `/manifest.json`, `/icon-192.png`, `/icon-512.png` after a fresh visit.
  - Reload a few times → `forge-static-…` picks up `/_next/static/*` chunks.
  - Network tab → set **Offline** → reload → app shell still renders.
  - `/api/sync` calls fail (correct — they're network-only and we're offline) but the cached app shell loads.
  - Append `?nosw=1` → caches and SW go away.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gucgxvub2JW5XT1q9dhU8f)_