### PR TITLE
Visual polish: focus accents, per-day rim glows, victory gradient, Portra grain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 Items in flight on `main` but not yet tagged. Tagged releases will move them into a dated section below.
 
 ### Added
+- **Visual polish — focus-aware accents, per-day rim glows, victory gradient, Kodak Portra grain.** Four small touches that add depth without breaking the editorial restraint:
+  - **Focus-aware accent.** New `T.focusAccent` palette (Forged = gold, Strong = deeper coral, Sculpt = soft mauve-rose). Surfaces as a third backdrop rim glow on home + the italic flourish colour on the home headline ("Squat & Push" italic now reads in the user's identity colour). Day-type accent stays dominant — focus is the quieter "you-are-here" layer.
+  - **Per-day rim lighting.** Each day type's secondary glow now sits in a different corner with a different size — strength leads from top-right (intense), Z2 drifts from bottom-left (settled), HIIT counterbalances top-left (sharp), cardio sits mid-right (sustained), rest near-invisible. Backdrop gains dimensional depth without adding chrome.
+  - **DoneScreen victory gradient.** Tighter warm-peach radial above the headline + a broader linear wash extending down. Lands a small triumph beat at the moment the user has just put the work in — non-patronising, on-brand.
+  - **Kodak Portra grain.** New `<GrainOverlay/>` component mounted once in `app/layout.jsx`. Inline SVG `feTurbulence` noise, warm-tinted via colour matrix, ~5% opacity, `mix-blend-mode: overlay`. Adds a lived-in tactility to every surface without competing with any content. Pure CSS / no asset to ship.
 - **Session overview sheet — jump to any block mid-session.** Tap the session-name area in the SessionScreen header (now with a small `▾` indicator) to open a bottom-sheet listing every block in today's session with its state (Current · Done · Partial · Up next) and `pairs/total sets` progress. Tap any block to jump to it; the engine resumes `setNum` from the draft log so a partially-completed block picks up at the right next set. Auto-advance still happens for users who don't open this surface — it's an escape hatch for busy gyms, not a default-flow change.
 
 ### Fixed

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -4,6 +4,7 @@ import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import ServiceWorkerRegistrar from "@/components/ServiceWorkerRegistrar";
+import GrainOverlay from "@/components/GrainOverlay";
 
 const fraunces = Fraunces({
   subsets: ["latin"],
@@ -57,6 +58,10 @@ export default function RootLayout({ children }) {
         <ErrorBoundary>
           {children}
         </ErrorBoundary>
+        {/* Kodak Portra-flavour grain texture. Mounted last in the body so
+            it composites on top via mix-blend overlay; pointer-events none
+            and zIndex 1 keep it strictly cosmetic. */}
+        <GrainOverlay />
         <Analytics />
         <SpeedInsights />
       </body>

--- a/components/ForgeApp.jsx
+++ b/components/ForgeApp.jsx
@@ -2732,13 +2732,53 @@ function HomeScreen({rhythm,profileName,userWeek,strengthDaySessions,onEditWeek,
   // Actual date of the viewed day (from the mount-time anchor above)
   const viewDate = new Date(nowMs + diffDays * 86400000);
 
+  // Focus accent (per-user identity). Forms a secondary rim glow + colours
+  // the italic flourish on the headline. Quiet by design — never competes
+  // with the day-type accent, just layers a "you-are-here" hint underneath.
+  const focusAccent = T.focusAccent[userFocus] || T.focusAccent.Forged;
+
+  // Per-day rim position for the secondary glow. Each day type's secondary
+  // sits in a different corner to give the backdrop a sense of movement and
+  // depth as the user scrubs through the week — strength leads from top-right
+  // (intense), Z2 drifts from bottom-left (settled), HIIT counterbalances top-
+  // left (sharp), cardio sits mid-right (sustained), rest near-invisible.
+  const dayRim = ({
+    strength: { top: -120, right: -80,    width: 360, height: 320 },
+    zone2:    { bottom: -120, left: -80,  width: 420, height: 360 },
+    hiit:     { top: -120, left: -80,     width: 320, height: 280 },
+    cardio:   { top: "30%", right: -120,  width: 360, height: 320 },
+    rest:     { top: "40%", left: "20%",  width: 280, height: 240 },
+  })[viewDay.type] || { top: -120, right: -80, width: 360, height: 320 };
+
   return (
     <div style={{minHeight:"100vh",paddingBottom:48,position:"relative",overflow:"hidden"}}>
-      {/* Ambient glow — colour transitions with the viewed day */}
+      {/* Primary ambient glow — top-centre, day-typed. The dominant signal. */}
       <div style={{
         position:"absolute",top:-180,left:"50%",transform:"translateX(-50%)",
         width:600,height:500,
         background:`radial-gradient(ellipse,${accent.glow} 0%,transparent 65%)`,
+        pointerEvents:"none",
+        transition:`background 400ms ${T.ease}`,
+      }}/>
+      {/* Per-day rim glow — gives the backdrop dimensional depth without
+          adding chrome. Position varies by day; colour matches the day's
+          accent at lower intensity so it reads as "second light source"
+          not "second voice". */}
+      <div style={{
+        position:"absolute",...dayRim,
+        background:`radial-gradient(circle,${accent.glow} 0%,transparent 70%)`,
+        opacity:0.55,
+        pointerEvents:"none",
+        transition:`all 500ms ${T.ease}`,
+      }}/>
+      {/* Focus-accent rim glow — quiet "you-are-here" layer in the user's
+          chosen identity colour. Bottom-right by convention; opacity low so
+          it never competes with the day-type signal above. */}
+      <div style={{
+        position:"absolute",bottom:-100,right:-60,
+        width:340,height:280,
+        background:`radial-gradient(ellipse,${focusAccent.glow} 0%,transparent 70%)`,
+        opacity:0.7,
         pointerEvents:"none",
         transition:`background 400ms ${T.ease}`,
       }}/>
@@ -2837,7 +2877,11 @@ function HomeScreen({rhythm,profileName,userWeek,strengthDaySessions,onEditWeek,
           <div style={{fontFamily:T.serif,fontSize:42,fontWeight:300,lineHeight:1.1}}>
             {cfg.headline[0]}<br/>
             {headline2 && (
-              <span style={{color:accent.main,fontStyle:"italic",transition:`color 300ms ${T.ease}`}}>
+              // Italic flourish takes the user's focus-accent colour, giving
+              // a quiet identity signal in the editorial typography itself —
+              // Sculpt's mauve, Strong's deeper coral, Forged's gold. The day-
+              // type accent remains the dominant visual via the rim glows.
+              <span style={{color:focusAccent.main,fontStyle:"italic",transition:`color 300ms ${T.ease}`}}>
                 {headline2}
               </span>
             )}
@@ -4584,7 +4628,13 @@ function DoneScreen({session,profileName,workingWeights,sessionStartWeights={},u
 
   return (
     <div style={{minHeight:"100vh",padding:"72px 24px 0",position:"relative",overflow:"hidden"}}>
-      <div style={{position:"absolute",top:-120,left:"50%",transform:"translateX(-50%)",width:420,height:380,background:`radial-gradient(circle,${T.strength.glow} 0%,transparent 65%)`,pointerEvents:"none"}}/>
+      {/* Victory gradient — warm peach wash from top-centre down. A small
+          non-patronising triumph beat at the moment the user has just put
+          the work in. Two stacked layers: a tight glow above the headline +
+          a broader linear wash so the warmth extends down without competing
+          with the body copy. */}
+      <div style={{position:"absolute",top:-120,left:"50%",transform:"translateX(-50%)",width:540,height:460,background:`radial-gradient(circle,${T.strength.glow} 0%,transparent 60%)`,pointerEvents:"none",opacity:1.15}}/>
+      <div style={{position:"absolute",inset:0,background:`linear-gradient(180deg, rgba(224,149,106,0.12) 0%, rgba(224,149,106,0.04) 22%, transparent 45%)`,pointerEvents:"none"}}/>
       <Fade d={0}>
         <div style={{fontFamily:T.serif,fontSize:13,fontWeight:300,fontStyle:"italic",color:T.text3,marginBottom:12}}>
           {profileName} · {session.name}

--- a/components/GrainOverlay.jsx
+++ b/components/GrainOverlay.jsx
@@ -1,0 +1,45 @@
+// GrainOverlay — adds a Kodak Portra-style warm grain texture to the whole
+// viewport. Pure-CSS / inline SVG; no asset to ship; mounted once in
+// app/layout.jsx so every screen gets the same lived-in feel without any
+// per-screen plumbing.
+//
+// Tuning: low frequency = chunkier grain (film-like); high numOctaves =
+// more detail; opacity ~5% keeps it strictly textural — visible on a flat
+// background, invisible behind any content. The colour matrix tints the
+// noise warm rather than neutral grey so it blends into Forge's cream
+// palette without going clinical.
+//
+// Pointer-events: none + zIndex 1 keeps it cosmetic — never intercepts
+// taps, never sits above modals (which set zIndex >= 300).
+
+const GRAIN_SVG = encodeURIComponent(
+  `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'>
+    <filter id='n'>
+      <feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/>
+      <feColorMatrix values='0 0 0 0 0.85
+                             0 0 0 0 0.78
+                             0 0 0 0 0.65
+                             0 0 0 0.7 0'/>
+    </filter>
+    <rect width='100%' height='100%' filter='url(#n)' opacity='1'/>
+  </svg>`
+);
+
+export default function GrainOverlay() {
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        position: "fixed",
+        inset: 0,
+        pointerEvents: "none",
+        zIndex: 1,
+        opacity: 0.05,
+        mixBlendMode: "overlay",
+        backgroundImage: `url("data:image/svg+xml,${GRAIN_SVG}")`,
+        backgroundRepeat: "repeat",
+        backgroundSize: "256px 256px",
+      }}
+    />
+  );
+}

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -32,6 +32,19 @@ export const T = {
   cardio:   { main: "#A5B8D0", dim: "rgba(165,184,208,0.09)", glow: "rgba(165,184,208,0.12)" },
   rest:     { main: "#6B6560", dim: "rgba(107,101,96,0.08)",  glow: "rgba(107,101,96,0.10)" },
 
+  // Focus accents — per-user identity colour. Forms a secondary rim glow on
+  // the home backdrop + colours the italic accent in the home headline.
+  // Quiet by design so the day-type accent stays the dominant signal; this
+  // is a "you-are-here" layer, not a competing voice.
+  //   Forged — gold (the existing default brand accent)
+  //   Strong — deeper coral / amber. Heavier, more intense.
+  //   Sculpt — soft mauve-rose. Refined, considered.
+  focusAccent: {
+    Forged: { main: "#C4A882", dim: "rgba(196,168,130,0.10)", glow: "rgba(196,168,130,0.16)" },
+    Strong: { main: "#D4754A", dim: "rgba(212,117,74,0.12)",  glow: "rgba(212,117,74,0.20)"  },
+    Sculpt: { main: "#C99BB1", dim: "rgba(201,155,177,0.10)", glow: "rgba(201,155,177,0.18)" },
+  },
+
   // Typography
   serif: "var(--font-fraunces), serif",
   sans: "var(--font-dm-sans), sans-serif",


### PR DESCRIPTION
Four small touches that add depth without breaking the editorial restraint.
Less-is-more applied throughout — quiet by design.

1. Focus-aware accent (lib/tokens.js + ForgeApp.jsx)
   - New T.focusAccent palette: Forged = gold (existing default), Strong =
     deeper coral / amber, Sculpt = soft mauve-rose.
   - Surfaces in two places: a third backdrop rim glow on the home
     screen (bottom-right, low opacity), and the italic flourish colour
     on the home headline ("Squat & Push" italic now reads in the
     user's identity colour).
   - Day-type accent remains the dominant visual signal — focus is
     the quieter "you-are-here" layer underneath.

2. Per-day rim lighting (ForgeApp.jsx HomeScreen)
   - The single top-centre glow stays as the dominant signal. A
     SECOND rim glow now sits in a different corner per day type:
       strength → top-right (intense, leading energy)
       zone2    → bottom-left (settled, calm drift)
       hiit     → top-left (sharp counterbalance)
       cardio   → mid-right (sustained)
       rest     → near-invisible
   - Backdrop gains dimensional depth as the user scrubs through the
     week, without adding any chrome.

3. DoneScreen victory gradient (ForgeApp.jsx)
   - Tighter warm-peach radial above the headline (existing glow,
     slightly stronger) plus a broader linear wash extending down
     ~45% of the viewport. Compositionally: a small triumph beat at
     the moment the user has just put in the work. Non-patronising,
     on-brand, no animation needed.

4. Kodak Portra grain (components/GrainOverlay.jsx + app/layout.jsx)
   - New GrainOverlay component. Inline SVG feTurbulence noise (no
     asset to ship), warm-tinted via colour matrix to blend into the
     cream palette, ~5% opacity, mix-blend-mode overlay.
   - Mounted once at the body level so every screen inherits the
     lived-in texture. pointer-events: none + zIndex 1 keeps it
     strictly cosmetic — never intercepts taps, never sits above
     modals (zIndex >= 300).

Suite 290/290, lint + build clean. No engine changes; pure visual.