### PR TITLE
Honest streak-badge label + lock the strength-only invariant

### DIFF
--- a/components/ForgeApp.jsx
+++ b/components/ForgeApp.jsx
@@ -5336,14 +5336,19 @@ function Tag({children,color,style={}}){return <span style={{display:"inline-fle
 function StreakBadge({rhythm}){
   const completed = rhythm?.completed || 0;
   const expected  = rhythm?.expected  || 12;
-  // If someone's going above the expected 3x/week, show "12+" rather than capping
+  // Window is a rolling 28-day count of strength sessions — labelled
+  // honestly. Used to say "this month", but a rolling window doesn't reset
+  // on the 1st, so users counting "since the month started" saw a mismatch
+  // (e.g. 5 strength sessions in June so far, badge says 6 because a late-
+  // May session is still inside the 28-day window).
+  const window  = rhythm?.window || 28;
   const over = completed > expected;
   const primary = over ? `${expected}+` : `${completed}`;
   const secondary = over ? "of 12 · strong" : `of ${expected}`;
   return (
     <div style={{background:T.bg2,border:`1px solid ${T.bg3}`,borderRadius:T.r.pill,padding:"8px 16px",display:"flex",alignItems:"center",gap:8}}>
       <span style={{fontFamily:T.serif,fontSize:22,fontWeight:400,color:T.gold,lineHeight:1}}>{primary}</span>
-      <div style={{fontSize:9,fontWeight:500,color:T.text3,letterSpacing:"0.1em",textTransform:"uppercase",lineHeight:1.5}}>{secondary}<br/>this month</div>
+      <div style={{fontSize:9,fontWeight:500,color:T.text3,letterSpacing:"0.1em",textTransform:"uppercase",lineHeight:1.5}}>{secondary}<br/>past {window} days</div>
     </div>
   );
 }

--- a/tests/retro-rhythm.test.js
+++ b/tests/retro-rhythm.test.js
@@ -123,3 +123,43 @@ describe("retro log → rhythm count", () => {
     expect(stored.session.startsWith("strength")).toBe(true);
   });
 });
+
+// ─── Rhythm scope: strength-only ────────────────────────────────────────────
+// User hypothesised "I've swapped a cardio day to Friday — does marking it
+// hit the streak badge?" The badge is meant to count strength sessions
+// only. handleMarkDayDone (the cardio/Z2/HIIT tick path) writes to
+// weekDone, never to history, so it can't inflate rhythm structurally.
+// Even if a non-strength record DID end up in history, computeRhythm's
+// filter would reject it. Lock both invariants.
+describe("computeRhythm — strength-only scope", () => {
+  it("non-strength history records do not count", () => {
+    // Construct records that LOOK like sessions but whose session strings
+    // aren't strength: z2, hiit, cardio, rest. computeRhythm should ignore
+    // every one of them.
+    const today = new Date().toISOString().slice(0, 10);
+    const fakes = ["z2", "hiit", "cardio", "rest"].map((kind, i) => ({
+      v: 2,
+      id: `${today}T${String(8 + i).padStart(2, "0")}:00:00.000Z`,
+      date: today,
+      session: kind,
+      readiness: "normal",
+      blocks: [],
+      summary: { totalVolume: 0 },
+    }));
+    fakes.forEach(r => H.append(PROFILE, r));
+    expect(computeRhythm(H.get(PROFILE)).completed).toBe(0);
+  });
+
+  it("ticking a day via weekDone never produces a history record", async () => {
+    // P.markDayDone updates weekDone for the current ISO week. It does NOT
+    // touch the history store. This test reads the history before and
+    // after a tick and asserts no record appeared — proving that the
+    // streak badge can't move just from a cardio tick.
+    const { P } = await import("../lib/storage.js");
+    const before = H.get(PROFILE);
+    P.markDayDone(PROFILE, 4); // Friday
+    const after = H.get(PROFILE);
+    expect(after.length).toBe(before.length);
+    expect(computeRhythm(after).completed).toBe(computeRhythm(before).completed);
+  });
+});


### PR DESCRIPTION
User reported the badge said 6 but they could only account for 5 strength
sessions since June started. Hypothesis: cardio ticks were inflating the
count.

They aren't, and structurally can't:
- handleMarkDayDone writes to weekDone (the per-week tick store), never
  to history.
- computeRhythm explicitly filters by rec.session.startsWith("strength")
  — a non-strength history record (if any existed) wouldn't count either.

The actual cause is the label. The badge said "this month" but the window
is a rolling 28 days. The user counts "since June started" (12 days), the
badge measures 28 days back, and a single late-May session is enough to
explain 5 → 6.

Fixed the label to "past N days" (read from rhythm.window so it stays in
sync if the constant ever changes). Added two regression tests:
- non-strength records (z2/hiit/cardio/rest) don't count toward rhythm
- ticking via P.markDayDone never adds to history

346 tests passing, lint + build + typecheck clean.