### PR TITLE
Catch-up rebuild — date-keyed, schedule-type-aware, slick picker

### DIFF
--- a/components/ForgeApp.jsx
+++ b/components/ForgeApp.jsx
@@ -10,7 +10,7 @@ import {
   bonusForDay,
   FOCUS_OPTIONS, DEFAULT_FOCUS, FOCUS_SUMMARIES, applyFocusToSession, applyRotationToSession, applySwapsToSession,
   // Retrospective logging helpers (compute past-date programme metadata + missing-day detection)
-  sessionMetaForDate, findRecentDays, hasMissedStrength, hasUntickedRecent, weekdayIdxForDate,
+  sessionMetaForDate, findRecentDays, hasMissedStrength, findUntickedRecent, weekdayIdxForDate,
 } from "@/lib/programme";
 import {
   LS, P, PB, W, F, H, BW, PN, bumpStreak,
@@ -18,7 +18,7 @@ import {
   blobPush, flushPendingPushes, getLocalProfile, backgroundSync, SyncStatus,
   enableAutoSync, disableAutoSync,
   checkProfileExists, claimProfile, blobDelete,
-  applyRpe, weeksSince,
+  applyRpe, weeksSince, dateOfWeekdayIdxInCurrentWeek,
   newDraftLog, logSet, finaliseDraft, scaleForReadiness, D, TS,
   inferLoadType, LOAD_TYPES, startingWeightForLift,
 } from "@/lib/storage";
@@ -333,6 +333,13 @@ export default function ForgeApp(){
   const [sessionSwaps,setSessionSwaps]=useState({});
   const [programmeBlock,setProgrammeBlock]=useState(()=>PB.get());
   const [weekDone,setWeekDone]=useState({});
+  // Date-keyed { [ISO date]: true }. Source of truth for "this day is done."
+  // Strength session finalises auto-write it; non-strength Mark ✓ writes it
+  // explicitly; cross-week back-marking just works because the key is the
+  // date, not the weekday-of-current-week. weekDone stays as a derived
+  // projection for the home week strip to render against without re-deriving
+  // the math at every cell.
+  const [dayDone,setDayDone]=useState({});
   const [bonusDone,setBonusDone]=useState({});
   const [userFocus,setUserFocus]=useState(DEFAULT_FOCUS);
   const [focusPickerOpen,setFocusPickerOpen]=useState(false);
@@ -519,19 +526,17 @@ export default function ForgeApp(){
   // without a reload. Falls back to the default WEEK when nothing is stored.
   const [userWeek, setUserWeek] = useState(() => W.get() || WEEK);
   const strengthDaySessions = useMemo(() => deriveStrengthDaySessions(userWeek), [userWeek]);
-  // Catch-up link surfaces when there's any unrecorded recent training day —
-  // missed strength session (logged via retro picker) OR untickered current-
-  // week non-strength day (zone-2 / HIIT / cardio, ticked via weekDone).
-  // hasMissedStrength stays in use for paths that want strength-only signal.
-  //
-  // Window: 7 days. Was 3 — but on Mondays a user with strength C on
-  // Thu/Fri/Sat from the previous week was already past the cutoff before
-  // they could log it. 7 days covers the full preceding training week
-  // without slipping into archaeology.
-  const hasRetroGaps = useMemo(
-    () => hasUntickedRecent(history, 7, weekDone, { week: userWeek }),
-    [history, weekDone, userWeek]
+  // Single source of truth for catch-up state. dayDone is date-keyed
+  // (`{ "2026-06-13": true, ... }`) — strength session finalises write it,
+  // the Mark ✓ path writes it explicitly. findUntickedRecent returns the
+  // actionable list (date + type + "log"/"tick" hint). Link surfaces when
+  // length > 0; picker drives off the same list; count goes into the
+  // editorial label so the user knows the scope up front.
+  const untickedDays = useMemo(
+    () => findUntickedRecent(history, 7, dayDone, { week: userWeek }),
+    [history, dayDone, userWeek]
   );
+  const hasRetroGaps = untickedDays.length > 0;
   const [weekEditorOpen, setWeekEditorOpen] = useState(false);
   const handleSaveWeek = (newWeek) => {
     W.save(newWeek);
@@ -565,6 +570,12 @@ export default function ForgeApp(){
     setWRState(local.meta.reps || {});
     setStreak(local.meta.streak?.count || 0);
     setProgrammeBlock(local.meta.programmeBlock || PB.get());
+    // dayDone tracks non-strength manual ticks (cardio/Z2/HIIT Mark ✓).
+    // Strength completion is history-backed — not mirrored here, because
+    // doing so would let a schedule edit (cardio → strength on a date that
+    // had a cardio tick) silently transmute into "strength completed."
+    // Two stores, two events; never conflated.
+    setDayDone(P.getDayDone(activeProfile));
     setWeekDone(P.getWeekDone(activeProfile));
     setBonusDone(P.getBonusDone(activeProfile));
     setUserFocus(F.get(activeProfile));
@@ -1022,7 +1033,12 @@ export default function ForgeApp(){
       if (draftLogRef.current) {
         sessionRecord = finaliseDraft(draftLogRef.current);
         H.append(activeProfile, sessionRecord);
-        // Reflect in React state so Performance Lab updates immediately
+        // Reflect in React state so Performance Lab updates immediately.
+        // NOTE: we deliberately do NOT write to dayDone here — strength
+        // completion is history-backed. Conflating the two stores would
+        // mean a cardio→strength schedule edit promotes the cardio tick
+        // into a "strength completed" mark, which corrupts the user's
+        // training record. dayDone is for non-strength manual ticks only.
         setHistory(H.get(activeProfile));
         draftLogRef.current = null;
       }
@@ -1225,15 +1241,35 @@ export default function ForgeApp(){
   // directly as onClick={onMarkDayDone}) falls through to "today". That
   // exact mistake shipped once — the home Mark complete button passed the
   // click event as idx and weekDone got keyed by "[object Object]".
-  const handleMarkDayDone = useCallback((idx)=>{
+  // Mark a non-strength day complete. Accepts either:
+  //   - a date string ("YYYY-MM-DD") — preferred, cross-week capable
+  //   - a weekday idx (0=Mon..6=Sun) — convenience for "today"; resolves to
+  //     today's date for that weekday within the current week
+  //   - nothing → today
+  // Streak only bumps when the resolved date IS today (no gaming the streak
+  // by backfilling). Writes to the date-keyed dayDone store; weekDone
+  // updates as a derived projection so the home week strip refreshes
+  // without separate state plumbing.
+  const handleMarkDayDone = useCallback((target)=>{
     if(!activeProfile) return;
-    const todayDow = new Date().getDay();
-    const todayMondayIdx = [6,0,1,2,3,4,5][todayDow];
-    const dayIdx = (Number.isInteger(idx) && idx >= 0 && idx <= 6) ? idx : todayMondayIdx;
-    const updated=P.markDayDone(activeProfile,dayIdx);
-    setWeekDone(updated);
-    if (dayIdx === todayMondayIdx) {
-      const newStreak=bumpStreak(activeProfile);
+    const todayDate = (() => {
+      const d = new Date(); d.setHours(0,0,0,0);
+      const y = d.getFullYear(), m = String(d.getMonth()+1).padStart(2,"0"), day = String(d.getDate()).padStart(2,"0");
+      return `${y}-${m}-${day}`;
+    })();
+    let dateStr;
+    if (typeof target === "string" && /^\d{4}-\d{2}-\d{2}$/.test(target)) {
+      dateStr = target;
+    } else if (Number.isInteger(target) && target >= 0 && target <= 6) {
+      dateStr = dateOfWeekdayIdxInCurrentWeek(target);
+    } else {
+      dateStr = todayDate;
+    }
+    const updatedDayDone = P.markDateDone(activeProfile, dateStr);
+    setDayDone(updatedDayDone);
+    setWeekDone(P.getWeekDone(activeProfile));
+    if (dateStr === todayDate) {
+      const newStreak = bumpStreak(activeProfile);
       setStreak(newStreak);
     }
   },[activeProfile]);
@@ -1639,6 +1675,10 @@ const sProps={
 
       H.append(activeProfile, sessionRecord);
       setHistory(H.get(activeProfile));
+      // No dayDone write here — strength completion is history-backed.
+      // See the live finalise path for the rationale (mixing the two
+      // stores would mean a schedule edit could promote a cardio tick
+      // into a phantom strength completion).
 
       // ─── Engine block — runs identically to live finalise hook ─────────
       try {
@@ -1846,13 +1886,13 @@ const sProps={
 
   return (
     <div style={{background:T.bg0,minHeight:"100vh",maxWidth:430,margin:"0 auto",fontFamily:T.sans,color:T.text1,WebkitFontSmoothing:"antialiased"}}>
-      {screen==="home"        && <HomeScreen rhythm={rhythm} profileName={activeProfile} userWeek={userWeek} strengthDaySessions={strengthDaySessions} onEditWeek={()=>setWeekEditorOpen(true)} onBegin={beginSession} onProfile={()=>setShowProfiles(true)} weekDone={weekDone} onMarkDayDone={handleMarkDayDone} bonusDone={bonusDone} onMarkBonusDone={handleMarkBonusDone} programmeBlock={programmeBlock} weeksOnBlock={weeksOnBlock} onRotate={handleRotate} onResetProgramme={handleResetProgramme} userFocus={userFocus} onEditFocus={()=>setFocusPickerOpen(true)} onPerformance={handleOpenPerformance} historyCount={history.length} recoveryNudge={recoveryNudge} onDismissRecovery={()=>setRecoveryDismissed(true)} syncState={syncState} pendingDraft={pendingDraft} onResumeDraft={handleResumeDraft} onDiscardDraft={handleDiscardDraft} showBwCard={bwIsStale && !bwCardDismissed} onOpenBwEdit={()=>setBwEditOpen(true)} onDismissBwCard={()=>setBwCardDismissed(true)} deloadOffer={deloadOffer} onAcceptDeload={handleAcceptDeload} onDismissDeload={handleDismissDeload} hasRetroGaps={hasRetroGaps} onOpenRetroPicker={handleOpenRetroPicker} retroToast={retroToast} onDismissRetroToast={()=>setRetroToast(null)} pnStage={pnStage} pnBusy={pnBusy} pnError={pnError} pnSuccessToast={pnSuccessToast} onPnRegister={handleRegisterPasskeyFromHome} onPnSnooze={handleSnoozeNudge} onPnDismissToast={()=>setPnSuccessToast(false)} tonnageMilestone={pendingMilestone} tonnageTotalKg={totalKg} onDismissTonnageMilestone={handleDismissTonnageMilestone} historyWeekDone={historyWeekDone}/>}
+      {screen==="home"        && <HomeScreen rhythm={rhythm} profileName={activeProfile} userWeek={userWeek} strengthDaySessions={strengthDaySessions} onEditWeek={()=>setWeekEditorOpen(true)} onBegin={beginSession} onProfile={()=>setShowProfiles(true)} weekDone={weekDone} onMarkDayDone={handleMarkDayDone} bonusDone={bonusDone} onMarkBonusDone={handleMarkBonusDone} programmeBlock={programmeBlock} weeksOnBlock={weeksOnBlock} onRotate={handleRotate} onResetProgramme={handleResetProgramme} userFocus={userFocus} onEditFocus={()=>setFocusPickerOpen(true)} onPerformance={handleOpenPerformance} historyCount={history.length} recoveryNudge={recoveryNudge} onDismissRecovery={()=>setRecoveryDismissed(true)} syncState={syncState} pendingDraft={pendingDraft} onResumeDraft={handleResumeDraft} onDiscardDraft={handleDiscardDraft} showBwCard={bwIsStale && !bwCardDismissed} onOpenBwEdit={()=>setBwEditOpen(true)} onDismissBwCard={()=>setBwCardDismissed(true)} deloadOffer={deloadOffer} onAcceptDeload={handleAcceptDeload} onDismissDeload={handleDismissDeload} untickedDays={untickedDays} onOpenRetroPicker={handleOpenRetroPicker} retroToast={retroToast} onDismissRetroToast={()=>setRetroToast(null)} pnStage={pnStage} pnBusy={pnBusy} pnError={pnError} pnSuccessToast={pnSuccessToast} onPnRegister={handleRegisterPasskeyFromHome} onPnSnooze={handleSnoozeNudge} onPnDismissToast={()=>setPnSuccessToast(false)} tonnageMilestone={pendingMilestone} tonnageTotalKg={totalKg} onDismissTonnageMilestone={handleDismissTonnageMilestone} historyWeekDone={historyWeekDone}/>}
       {screen==="readiness"   && <ReadinessScreen readiness={readiness} setReadiness={setReadiness} reason={readinessReason} setReason={setReadinessReason} onStart={handleReadinessStart}/>}
       {screen==="session"     && <ErrorBoundary><SessionScreen {...sProps}/></ErrorBoundary>}
       {screen==="done"        && <ErrorBoundary><DoneScreen session={activeSession} profileName={activeProfile} workingWeights={workingWeights} sessionStartWeights={sessionStartWeights} userWeek={userWeek} onHome={()=>{ setShowDeloadComplete(false); reset(); }} deloadCompleted={showDeloadComplete}/></ErrorBoundary>}
       {screen==="performance" && <ErrorBoundary><PerformanceLab history={history} onBack={()=>setScreen("home")}/></ErrorBoundary>}
       {screen==="retro"       && retroDate && <ErrorBoundary><RetrospectiveSessionSheet date={retroDate} bodyweight={bodyweight} workingWeights={workingWeights} workingReps={workingReps} userWeek={userWeek} onCancel={handleCancelRetro} onSubmit={handleSubmitRetro}/></ErrorBoundary>}
-      {retroPickerOpen        && <RetroPickerSheet history={history} pendingDraft={pendingDraft} weekDone={weekDone} userWeek={userWeek} onPick={handlePickRetroDate} onTickDay={handleMarkDayDone} onClose={()=>setRetroPickerOpen(false)}/>}
+      {retroPickerOpen        && <RetroPickerSheet untickedDays={untickedDays} pendingDraft={pendingDraft} onPick={handlePickRetroDate} onTickDate={handleMarkDayDone} onClose={()=>setRetroPickerOpen(false)}/>}
       {rotationSummary        && <RotationSummaryModal summary={rotationSummary} onContinue={handleRotationContinue}/>}
       {rotationPreview        && <RotationPreviewSheet preview={rotationPreview} onConfirm={handleRotationConfirm} onReroll={handleRotationReroll} onCancel={handleRotationCancel}/>}
       {showIosInstall         && <IosInstallOverlay onDismiss={()=>{ LS.set("forge:iosInstallDismissed", true); setShowIosInstall(false); }}/>}
@@ -2844,7 +2884,7 @@ function ProfileScreen({existing,current,onActivate,onCancel,bodyweight=null,bwE
 }
 
 // ─── Home ──────────────────────────────────��──────────────────────────────────
-function HomeScreen({rhythm,profileName,userWeek,strengthDaySessions,onEditWeek,onBegin,onProfile,weekDone={},onMarkDayDone,bonusDone={},onMarkBonusDone,programmeBlock,weeksOnBlock,onRotate,onResetProgramme,userFocus="Forged",onEditFocus,onPerformance,historyCount=0,recoveryNudge=null,onDismissRecovery,syncState="idle",pendingDraft=null,onResumeDraft,onDiscardDraft,showBwCard=false,onOpenBwEdit,onDismissBwCard,deloadOffer=null,onAcceptDeload,onDismissDeload,hasRetroGaps=false,onOpenRetroPicker,retroToast=null,onDismissRetroToast,pnStage="hidden",pnBusy=false,pnError=null,pnSuccessToast=false,onPnRegister,onPnSnooze,onPnDismissToast,tonnageMilestone=null,tonnageTotalKg=0,onDismissTonnageMilestone,historyWeekDone={}}){
+function HomeScreen({rhythm,profileName,userWeek,strengthDaySessions,onEditWeek,onBegin,onProfile,weekDone={},onMarkDayDone,bonusDone={},onMarkBonusDone,programmeBlock,weeksOnBlock,onRotate,onResetProgramme,userFocus="Forged",onEditFocus,onPerformance,historyCount=0,recoveryNudge=null,onDismissRecovery,syncState="idle",pendingDraft=null,onResumeDraft,onDiscardDraft,showBwCard=false,onOpenBwEdit,onDismissBwCard,deloadOffer=null,onAcceptDeload,onDismissDeload,untickedDays=[],onOpenRetroPicker,retroToast=null,onDismissRetroToast,pnStage="hidden",pnBusy=false,pnError=null,pnSuccessToast=false,onPnRegister,onPnSnooze,onPnDismissToast,tonnageMilestone=null,tonnageTotalKg=0,onDismissTonnageMilestone,historyWeekDone={}}){
   // Two-tap reset confirmation: first tap arms, second tap commits, 5s timeout disarms.
   const [resetArmed, setResetArmed] = useState(false);
   const resetTimerRef = useRef(null);
@@ -3407,12 +3447,14 @@ function HomeScreen({rhythm,profileName,userWeek,strengthDaySessions,onEditWeek,
           // tappability with explicit "Finish your live session first"
           // copy, so a user with an active draft sees the unmarked days
           // and understands why they can't log them yet. */}
-      {hasRetroGaps && onOpenRetroPicker && (
+      {untickedDays.length > 0 && onOpenRetroPicker && (
         <Fade d={190}>
           <div style={{margin:"18px 24px 0",display:"flex",justifyContent:"center"}}>
             <button onClick={onOpenRetroPicker}
               style={{background:"none",border:"none",padding:"6px 4px",cursor:"pointer",fontFamily:T.sans,fontSize:13,color:T.sage,letterSpacing:"0.01em"}}>
-              Missed a session? <span style={{fontStyle:"italic",fontFamily:T.serif,marginLeft:2}}>Log it</span> →
+              {untickedDays.length === 1
+                ? <>1 unmarked day — <span style={{fontStyle:"italic",fontFamily:T.serif,marginLeft:2}}>catch up</span> →</>
+                : <>{untickedDays.length} unmarked days — <span style={{fontStyle:"italic",fontFamily:T.serif,marginLeft:2}}>catch up</span> →</>}
             </button>
           </div>
         </Fade>
@@ -4611,43 +4653,43 @@ function DrumEditOverlay({target,workingWeights,setWW,workingReps,setWR,block,on
 // ─── Retro Picker Sheet ────────────────────────────────────────────────────────
 // Exported for direct component testing (tests/components/RetroPickerSheet.test.jsx).
 // Still rendered only via the in-file mount at <RetroPickerSheet ... /> below.
-export function RetroPickerSheet({history, pendingDraft, weekDone={}, userWeek=WEEK, onPick, onTickDay, onClose}){
-  // findRecentDays consults the WEEK schedule to label each recent day's type
-  // (strength / Z2 / HIIT / cardio / rest). Without userWeek threaded in, it
-  // falls back to the default WEEK constant — so users with edited schedules
-  // saw the "traditional" layout in the picker (strength labelled on the
-  // wrong days, picker un-tappable on the user's actual strength days, and
-  // RetrospectiveSessionSheet rendering an empty form when picks didn't
-  // match the user's schedule). Pass userWeek through so day-type labels
-  // and tappability match what RetrospectiveSessionSheet will see.
-  // Window matches the home-screen hasRetroGaps probe (also 7). Catches the
-  // common case of opening the app on Monday with a Thu/Fri/Sat strength
-  // session from the previous week still unlogged.
-  const rows = useMemo(() => findRecentDays(history, 7, { week: userWeek }), [history, userWeek]);
+// Ballerina-lean catch-up. The list is exactly what's unmarked — strength
+// days needing a retro log + non-strength days needing a tick. Each row has
+// one tap, one action. Ticks dismiss the row in place with a soft fade; the
+// sheet auto-closes when the last item clears, with a brief "All caught up"
+// micro-celebration. If the user has a live draft, rows render but are not
+// tappable, with explicit "Finish your live session first" copy.
+export function RetroPickerSheet({untickedDays=[], pendingDraft, onPick, onTickDate, onClose}){
   const draftBlocks = !!pendingDraft;
   const { containerRef, onKeyDown } = useModalA11y(onClose);
   const titleId = "retro-picker-title";
 
-  // For non-strength rows, "ticked" = the day's weekday-idx is in weekDone.
-  // Past-week days can't be ticked (weekDone is current-week-scoped) — we
-  // mark those as non-actionable in the UI so users don't tap fruitlessly.
-  const todayMonday = (() => {
-    const d = new Date(); d.setHours(0,0,0,0);
-    const dow = d.getDay();
-    const delta = dow === 0 ? -6 : 1 - dow;
-    d.setDate(d.getDate() + delta);
-    const y = d.getFullYear(), m = String(d.getMonth()+1).padStart(2,"0"), day = String(d.getDate()).padStart(2,"0");
-    return `${y}-${m}-${day}`;
-  })();
-  const sameWeekAsToday = (dateStr) => {
-    const [y, m, d] = dateStr.split("-").map(Number);
-    const date = new Date(y, m-1, d);
-    const dow = date.getDay();
-    const delta = dow === 0 ? -6 : 1 - dow;
-    date.setDate(date.getDate() + delta);
-    const yy = date.getFullYear(), mm = String(date.getMonth()+1).padStart(2,"0"), dd = String(date.getDate()).padStart(2,"0");
-    return `${yy}-${mm}-${dd}` === todayMonday;
-  };
+  // Local view-state: track which rows have been dismissed in-place during
+  // this sheet session. The parent list (untickedDays) refreshes on close
+  // and re-render via the dayDone state in ForgeApp — but for the duration
+  // of this open, we want the fade-out + auto-close to feel instant.
+  const [dismissed, setDismissed] = useState(() => new Set());
+  const [celebrate, setCelebrate] = useState(false);
+  const visible = untickedDays.filter(r => !dismissed.has(r.date));
+
+  // Auto-close when the last row clears. Tiny celebratory beat first
+  // (200ms hold) so the user actually feels the "done" before the sheet
+  // dissolves — without it, the close feels sudden and joyless.
+  const lastVisibleCount = useRef(visible.length);
+  useEffect(() => {
+    if (lastVisibleCount.current > 0 && visible.length === 0) {
+      setCelebrate(true);
+      const t = setTimeout(() => onClose?.(), 1100);
+      return () => clearTimeout(t);
+    }
+    lastVisibleCount.current = visible.length;
+  }, [visible.length, onClose]);
+
+  const dismissRow = (dateStr) => setDismissed(prev => {
+    const next = new Set(prev);
+    next.add(dateStr);
+    return next;
+  });
 
   return (
     <div onKeyDown={onKeyDown} onClick={onClose} style={{position:"fixed",inset:0,background:"rgba(10,9,8,0.92)",zIndex:400,display:"flex",alignItems:"flex-end",justifyContent:"center"}}>
@@ -4655,85 +4697,73 @@ export function RetroPickerSheet({history, pendingDraft, weekDone={}, userWeek=W
 
         <div style={{display:"flex",justifyContent:"space-between",alignItems:"flex-start",marginBottom:18}}>
           <div>
-            <div id={titleId} style={{fontFamily:T.serif,fontSize:22,fontWeight:300,lineHeight:1.1}}>Recent days</div>
-            <div style={{fontSize:12,color:T.text3,marginTop:4,lineHeight:1.5}}>
-              {draftBlocks ? "Finish your live session first" : "Log a missed session or tick off a non-strength day"}
+            <div id={titleId} style={{fontFamily:T.serif,fontSize:22,fontWeight:300,lineHeight:1.1}}>
+              {celebrate ? "All caught up." : (visible.length === 1 ? "1 unmarked day" : `${visible.length} unmarked days`)}
             </div>
+            {!celebrate && (
+              <div style={{fontSize:12,color:T.text3,marginTop:4,lineHeight:1.5}}>
+                {draftBlocks ? "Finish your live session first" : "Tap to log a missed session — or tick the rest off"}
+              </div>
+            )}
           </div>
           <button onClick={onClose} aria-label="Close" style={{background:T.bg3,border:`1px solid ${T.bg4}`,borderRadius:T.r.sm,padding:"6px 10px",cursor:"pointer",color:T.text2,fontSize:13,flexShrink:0}}>✕</button>
         </div>
 
-        <div style={{display:"flex",flexDirection:"column",gap:8}}>
-          {rows.map((row) => {
-            const isStrength = row.type === "strength";
-            const isRest     = row.type === "rest";
-            // Non-strength check: is this day ticked already? Pull the
-            // weekday-idx, look it up in weekDone. Past-week days can't be
-            // ticked (different week storage) — surfaced as informational only.
-            const weekdayIdx = weekdayIdxForDate(row.date);
-            const inThisWeek = sameWeekAsToday(row.date);
-            const ticked     = !isStrength && !isRest && inThisWeek && !!weekDone[weekdayIdx];
-            const tappableStrength    = isStrength && !row.logged && !draftBlocks;
-            const tappableNonStrength = !isStrength && !isRest && inThisWeek && !ticked && !draftBlocks;
-            const tappable = tappableStrength || tappableNonStrength;
-            const accentColor = isStrength
-              ? (row.logged ? T.text4 : T.coral)
-              : (ticked ? T.sage : (tappableNonStrength ? T.sage : T.text4));
-            const opacity = draftBlocks ? 0.4
-              : isRest ? 0.55
-              : (row.logged || ticked) ? 0.7
-              : (!isStrength && !inThisWeek) ? 0.55
-              : 1;
-            const bg = tappableStrength    ? `${T.coral}0A`
-                     : tappableNonStrength ? `${T.sage}0A`
-                     : T.bg3;
-            const borderColor = tappableStrength    ? `${T.coral}33`
-                              : tappableNonStrength ? `${T.sage}33`
-                              : T.bg4;
+        {/* Celebration state — the list has cleared. Tiny editorial flourish
+            so the close feels earned rather than abrupt. The auto-close
+            timer above will dismiss the sheet shortly after. */}
+        {celebrate && (
+          <div style={{padding:"24px 8px",textAlign:"center",fontFamily:T.serif,fontStyle:"italic",fontSize:15,color:T.sage,lineHeight:1.5}}>
+            Back to it.
+          </div>
+        )}
 
-            const onTap = tappableStrength
-              ? () => onPick(row.date)
-              : tappableNonStrength
-                ? () => { onTickDay?.(weekdayIdx); }
-                : undefined;
-
-            return (
-              <div key={row.date}
-                onClick={onTap}
-                style={{
-                  padding:"14px 16px",
-                  background: bg,
-                  border: `1px solid ${borderColor}`,
-                  borderRadius: T.r.md,
-                  cursor: tappable ? "pointer" : "default",
-                  display:"flex",alignItems:"center",justifyContent:"space-between",
-                  opacity,
-                  transition: `all 180ms ${T.ease}`,
-                }}>
-                <div style={{display:"flex",flexDirection:"column",gap:2}}>
-                  <div style={{fontFamily:T.serif,fontSize:16,fontWeight:300,color:T.text1,lineHeight:1.2}}>
-                    {row.dateLabel}
+        {!celebrate && (
+          <div style={{display:"flex",flexDirection:"column",gap:8}}>
+            {visible.map((row) => {
+              const isLog = row.action === "log";
+              const colour = isLog ? T.coral : T.sage;
+              const onTap = draftBlocks ? undefined : (isLog
+                ? () => onPick?.(row.date)
+                : () => { onTickDate?.(row.date); dismissRow(row.date); }
+              );
+              return (
+                <div key={row.date}
+                  onClick={onTap}
+                  style={{
+                    padding:"14px 16px",
+                    background: draftBlocks ? T.bg3 : `${colour}0A`,
+                    border: `1px solid ${draftBlocks ? T.bg4 : colour+"33"}`,
+                    borderRadius: T.r.md,
+                    cursor: draftBlocks ? "default" : "pointer",
+                    display:"flex",alignItems:"center",justifyContent:"space-between",
+                    opacity: draftBlocks ? 0.5 : 1,
+                    animation: `fadeSlide 220ms ${T.ease}`,
+                    transition: `all 180ms ${T.ease}`,
+                  }}>
+                  <div style={{display:"flex",flexDirection:"column",gap:2}}>
+                    <div style={{fontFamily:T.serif,fontSize:16,fontWeight:300,color:T.text1,lineHeight:1.2}}>
+                      {row.dateLabel}
+                    </div>
+                    <div style={{display:"flex",alignItems:"center",gap:6}}>
+                      <span style={{display:"inline-block",width:5,height:5,borderRadius:"50%",background:colour}}/>
+                      <span style={{fontSize:11,color:T.text3,letterSpacing:"0.04em"}}>
+                        {row.sessionName}
+                      </span>
+                    </div>
                   </div>
-                  <div style={{display:"flex",alignItems:"center",gap:6}}>
-                    <span style={{display:"inline-block",width:5,height:5,borderRadius:"50%",background:accentColor}}/>
-                    <span style={{fontSize:11,color:T.text3,letterSpacing:"0.04em"}}>
-                      {row.sessionName}
-                      {row.logged && " · logged"}
-                      {ticked && " · ticked"}
-                    </span>
-                  </div>
+                  {!draftBlocks && (isLog
+                    ? <span style={{fontSize:18,color:T.coral}}>→</span>
+                    : <span style={{fontSize:13,fontWeight:500,color:T.sage,letterSpacing:"0.04em"}}>Mark ✓</span>
+                  )}
                 </div>
-                {tappableStrength    && <span style={{fontSize:18,color:T.coral}}>→</span>}
-                {tappableNonStrength && <span style={{fontSize:13,fontWeight:500,color:T.sage,letterSpacing:"0.04em"}}>Mark ✓</span>}
-                {isRest              && <span style={{fontSize:10,color:T.text4,fontStyle:"italic",fontFamily:T.serif}}>rest</span>}
-                {(row.logged || ticked) && <span style={{fontSize:11,color:T.sage,fontWeight:500,letterSpacing:"0.06em",textTransform:"uppercase"}}>✓</span>}
-              </div>
-            );
-          })}
-        </div>
+              );
+            })}
+          </div>
+        )}
 
         <div style={{marginTop:16,fontSize:11,color:T.text4,fontStyle:"italic",fontFamily:T.serif,textAlign:"center",lineHeight:1.5}}>
-          Only the last week. Anything older is archaeology.
+          {celebrate ? "" : "Only the last week. Anything older is archaeology."}
         </div>
       </div>
     </div>

--- a/lib/programme.js
+++ b/lib/programme.js
@@ -1189,19 +1189,44 @@ function localMondayOfWeek(dateStr) {
 //
 // Past-week days don't count — weekDone is current-week scoped, so we'd
 // have no way to record the tick. The link stays hidden in that case.
-export function hasUntickedRecent(history = [], daysBack = 3, weekDone = {}, { week = WEEK } = {}) {
+/**
+ * Returns the recent training days that are still unmarked. Each row carries
+ * an `action` hint:
+ *   - "log"  — strength day, no history record. The retro session sheet is
+ *              the way through.
+ *   - "tick" — non-strength training day (cardio/Z2/HIIT). One-tap Mark ✓
+ *              writes dayDone[date] = true.
+ *
+ * Rest days are excluded (nothing to mark). Today is excluded (still might
+ * train it). dayDone is the unified "this date is done" store — strength
+ * session finalises auto-write it, the Mark ✓ path writes it explicitly.
+ * No past-week guard, no idx-based lookups: cross-week back-marking is the
+ * point of the date-keyed store.
+ */
+export function findUntickedRecent(history = [], daysBack = 7, dayDone = {}, { week = WEEK } = {}) {
   const rows = findRecentDays(history, daysBack, { week });
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  const thisMonday = localMondayOfWeek(localDateStr(today));
-  return rows.some(r => {
-    if (r.type === "rest") return false;
-    if (r.type === "strength") return !r.logged;
-    if (localMondayOfWeek(r.date) !== thisMonday) return false;
-    const [y, m, d] = r.date.split("-").map(Number);
-    const dow = new Date(y, m - 1, d).getDay();
-    return !weekDone[SUNSTART_TO_MONSTART[dow]];
-  });
+  const out = [];
+  for (const r of rows) {
+    if (r.type === "rest") continue;
+    // SCHEDULE-TYPE drives WHICH store proves completion. Strength is
+    // history-backed (only a real session record counts); non-strength is
+    // dayDone-backed (manual Mark ✓). Editing the schedule must NEVER
+    // promote a cardio tick into a "strength completed" — type lives in
+    // userWeek, completion proof lives in the type's own store.
+    if (r.type === "strength") {
+      if (r.logged) continue;
+      out.push({ ...r, action: "log" });
+    } else {
+      if (dayDone[r.date]) continue;
+      out.push({ ...r, action: "tick" });
+    }
+  }
+  return out;
+}
+
+// Boolean wrapper — historical callers that only need a presence check.
+export function hasUntickedRecent(history = [], daysBack = 7, dayDone = {}, { week = WEEK } = {}) {
+  return findUntickedRecent(history, daysBack, dayDone, { week }).length > 0;
 }
 
 // Translate a date string ("YYYY-MM-DD") into the monday-start weekday

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -86,13 +86,43 @@ export const P = {
   saveReps:     (n, r)   => LS.set(`forge:${n}:reps`, r),
   getStreak:    (n)      => LS.get(`forge:${n}:streak`, { count: 0, lastDate: null }),
   saveStreak:   (n, s)   => LS.set(`forge:${n}:streak`, s),
-  getWeekDone:  (n)      => LS.get(`forge:${n}:weekDone:${weekKey()}`, {}),
-  saveWeekDone: (n, d)   => LS.set(`forge:${n}:weekDone:${weekKey()}`, d),
-  markDayDone:  (n, idx) => {
-    const d = P.getWeekDone(n);
-    const next = { ...d, [idx]: true };
-    P.saveWeekDone(n, next);
+
+  // Day-completion store — date-keyed. Records "user marked this non-strength
+  // day complete." Strength days don't write here; the source of truth for
+  // strength completion is whether a session record exists in history for
+  // that date. Cross-week back-marking just works because the key is the
+  // ISO date string, not the weekday-of-current-week.
+  //
+  // Replaces the older weekKey-scoped weekDone store. getWeekDone is kept
+  // as a projection so the home week strip can still look up "is THIS week's
+  // Wednesday done?" without re-deriving the math at every call site.
+  getDayDone:    (n)            => LS.get(`forge:${n}:dayDone`, {}),
+  markDateDone:  (n, dateStr)   => {
+    if (!n || !dateStr) return P.getDayDone(n);
+    const d = P.getDayDone(n);
+    if (d[dateStr]) return d;
+    const next = { ...d, [dateStr]: true };
+    LS.set(`forge:${n}:dayDone`, next);
     return next;
+  },
+  // Back-compat: idx-based mark, resolves to today's date for that weekday.
+  // Only correct for the current week — kept for the home "Mark complete"
+  // button on today. Past-day callers should use markDateDone directly.
+  markDayDone:  (n, idx) => {
+    if (typeof idx !== "number") return P.getDayDone(n);
+    const dateStr = dateOfWeekdayIdxInCurrentWeek(idx);
+    return P.markDateDone(n, dateStr);
+  },
+  // Project dayDone onto the current week as { 0..6: true } so the home
+  // week strip can render without knowing about ISO dates.
+  getWeekDone:  (n) => {
+    const days = P.getDayDone(n);
+    const out = {};
+    for (let i = 0; i < 7; i++) {
+      const dateStr = dateOfWeekdayIdxInCurrentWeek(i);
+      if (days[dateStr]) out[i] = true;
+    }
+    return out;
   },
   // Cardio-day bonus completion. Deliberately a SEPARATE per-week store from
   // weekDone so it can never influence streak/rhythm — bonuses are optional
@@ -693,6 +723,22 @@ export function weekKey() {
   const mon = new Date(d);
   mon.setDate(diff);
   return mon.toISOString().slice(0, 10);
+}
+
+// Resolve a Forge weekday index (0=Mon..6=Sun) to its LOCAL ISO date string
+// within the current week. Used so day-done lookups stay date-keyed even when
+// the caller thinks in weekday indices (e.g. the home week strip rendering
+// loop). Local time so DST and timezones don't shift the day.
+export function dateOfWeekdayIdxInCurrentWeek(weekdayIdx) {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  const dow = d.getDay();                            // 0=Sun..6=Sat
+  const monShift = dow === 0 ? -6 : 1 - dow;         // shift to local Monday
+  d.setDate(d.getDate() + monShift + weekdayIdx);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
 }
 
 // ─── Schema versioning ────────────────────────────────────────────────────────

--- a/tests/components/RetroPickerSheet.test.jsx
+++ b/tests/components/RetroPickerSheet.test.jsx
@@ -1,138 +1,127 @@
 // @vitest-environment jsdom
 // ─────────────────────────────────────────────────────────────────────────────
-// First component-level test. Two regressions in one file:
+// RetroPickerSheet contract tests, updated for the date-keyed catch-up model.
 //
-//   1. RetroPickerSheet must thread the user's edited weekly schedule through
-//      to findRecentDays. Without it (PR #100 root cause) the sheet labelled
-//      strength on the wrong day and rendered the retro-session form empty
-//      when picks didn't match the user's actual week.
+//   1. Parent supplies `untickedDays` — a pre-computed list of action rows
+//      (date/dateLabel/type/sessionName/action). The picker is now a pure
+//      view over that list; no internal findRecentDays call, no internal
+//      week-of-current-week math, no past-week guard.
 //
-//   2. The "Mark ✓" tap must call onTickDay with an integer weekday index,
-//      NOT a React SyntheticEvent. PR #101 (today's bug) shipped that wrong:
-//      `onClick={onTickDay}` was passing the event object as idx, which
-//      meant the day never ticked because the storage key collapsed to
-//      "[object Object]". The handler now sits behind a wrapper; this test
-//      asserts the contract from the component side.
+//   2. Mark ✓ tap calls onTickDate with the row's ISO DATE STRING. The
+//      old contract passed a weekday index (0..6); switching the store
+//      to date-keyed makes the index obsolete and lets cross-week
+//      back-marking just work.
 //
-// This is also the bootstrap example for the component-testing setup
-// (vitest + jsdom + @testing-library/react). Future component tests should
-// follow the same per-file `@vitest-environment jsdom` directive so the
-// pure-lib suite stays on the fast node environment.
+//   3. Strength rows have action: "log" and fire onPick(date). Non-strength
+//      rows have action: "tick" and fire onTickDate(date).
+//
+//   4. The picker auto-celebrates + closes when the visible list clears.
 // ─────────────────────────────────────────────────────────────────────────────
 
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { RetroPickerSheet } from "../../components/ForgeApp.jsx";
 
-// `globals: false` in vitest config disables RTL's auto-cleanup — wire it
-// explicitly so DOM from a previous test doesn't leak and produce
-// "multiple elements found" errors on the next query.
 afterEach(() => {
   cleanup();
 });
 
-// A custom week that puts strength on Tuesday only — everything else is
-// rest. With the bug, the default WEEK constant runs and strength surfaces
-// on the wrong day; with the fix, the Tuesday row carries the "Strength"
-// label and nothing else does.
-const customWeek = [
-  { type: "rest",     label: "Rest",     s: "Mo" }, // idx 0 = Mon
-  { type: "strength", label: "Strength", s: "Tu" }, // idx 1 = Tue
-  { type: "z2",       label: "Z2 — 60 min", s: "We" },
-  { type: "rest",     label: "Rest",     s: "Th" },
-  { type: "rest",     label: "Rest",     s: "Fr" },
-  { type: "rest",     label: "Rest",     s: "Sa" },
-  { type: "rest",     label: "Rest",     s: "Su" },
-];
+const z2Row = (date) => ({
+  date,
+  dateLabel: `Day ${date}`,
+  type: "z2",
+  sessionName: "Z2 — 60 min",
+  action: "tick",
+});
+const strengthRow = (date) => ({
+  date,
+  dateLabel: `Day ${date}`,
+  type: "strength",
+  sessionName: "Strength A",
+  action: "log",
+});
 
-describe("RetroPickerSheet — schedule + handler wiring", () => {
-  it("renders strength on the day the user's custom week marks strength", () => {
+describe("RetroPickerSheet — date-keyed catch-up", () => {
+  it("renders one row per untickedDays entry", () => {
     render(
       <RetroPickerSheet
-        history={[]}
+        untickedDays={[strengthRow("2026-06-13"), z2Row("2026-06-12")]}
         pendingDraft={null}
-        weekDone={{}}
-        userWeek={customWeek}
         onPick={() => {}}
-        onTickDay={() => {}}
+        onTickDate={() => {}}
         onClose={() => {}}
       />
     );
-    // The "Recent days" heading proves we rendered. Then we count strength
-    // pills in the trailing 3-day window. Only days that map to Tuesday in
-    // the customWeek should carry "Strength" — at most one of the last 3
-    // days is a Tuesday, so the count must be 0 or 1.
-    expect(screen.getByText("Recent days")).toBeTruthy();
-    const strengthPills = screen.queryAllByText("Strength");
-    expect(strengthPills.length).toBeLessThanOrEqual(1);
+    expect(screen.getByText("2 unmarked days")).toBeTruthy();
+    expect(screen.getByText("Strength A")).toBeTruthy();
+    expect(screen.getByText("Z2 — 60 min")).toBeTruthy();
   });
 
-  it("Mark ✓ tap calls onTickDay with an INTEGER weekday index, not a SyntheticEvent", () => {
-    // Set up so the most recent day is a tappable non-strength training day
-    // by giving the entire trailing 3 days a single z2 slot. The sheet will
-    // surface a "Mark ✓" affordance for the current-week z2 day; clicking
-    // it must pass an integer (0..6) to onTickDay.
-    // Pin "today" to a Wednesday so the trailing 3-day window
-    // (Tue/Mon/Sun) overlaps the current Mon-start week. RetroPickerSheet
-    // only renders "Mark ✓" for days in the current week; without pinning,
-    // running on real Mondays leaves the window entirely in last week and
-    // no Mark ✓ pills render. Same CI-Monday flake that broke
-    // hasUntickedRecent's test.
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-06-17T10:00:00")); // local Wed
-    const z2Week = Array(7).fill({ type: "z2", label: "Z2", s: "X" });
-    const onTickDay = vi.fn();
+  it("Mark ✓ tap calls onTickDate with the row's ISO DATE STRING", () => {
+    // Old contract passed a weekday index (0..6). The new store is date-keyed
+    // so the picker fires the actual date, which works cross-week without
+    // any current-week-only fragility.
+    const onTickDate = vi.fn();
     render(
       <RetroPickerSheet
-        history={[]}
+        untickedDays={[z2Row("2026-06-12")]}
         pendingDraft={null}
-        weekDone={{}}
-        userWeek={z2Week}
         onPick={() => {}}
-        onTickDay={onTickDay}
+        onTickDate={onTickDate}
         onClose={() => {}}
       />
     );
-    // Find a "Mark ✓" pill and click it
-    const markPills = screen.queryAllByText("Mark ✓");
-    expect(markPills.length).toBeGreaterThan(0);
-    fireEvent.click(markPills[0]);
-    // The handler must be called exactly once, with an integer in [0,6].
-    expect(onTickDay).toHaveBeenCalledTimes(1);
-    const idx = onTickDay.mock.calls[0][0];
-    expect(Number.isInteger(idx)).toBe(true);
-    expect(idx).toBeGreaterThanOrEqual(0);
-    expect(idx).toBeLessThanOrEqual(6);
-    vi.useRealTimers();
+    fireEvent.click(screen.getByText("Mark ✓"));
+    expect(onTickDate).toHaveBeenCalledTimes(1);
+    expect(onTickDate.mock.calls[0][0]).toBe("2026-06-12");
   });
 
-  it("strength row tap calls onPick with the row's ISO date", () => {
-    // Yesterday-strength setup: today is some day; the recent window
-    // includes whichever days fall in the last 3 — at most one of them
-    // matches Tuesday in customWeek. We don't assert that one exists;
-    // we assert that if a "Strength" pill is present, tapping it fires
-    // onPick with a YYYY-MM-DD string.
+  it("strength row tap calls onPick with the row's ISO DATE STRING", () => {
     const onPick = vi.fn();
     render(
       <RetroPickerSheet
-        history={[]}
+        untickedDays={[strengthRow("2026-06-13")]}
         pendingDraft={null}
-        weekDone={{}}
-        userWeek={customWeek}
         onPick={onPick}
-        onTickDay={() => {}}
+        onTickDate={() => {}}
         onClose={() => {}}
       />
     );
-    const strengthPills = screen.queryAllByText("Strength");
-    if (strengthPills.length === 0) return; // no strength in the last 3 days right now — skip
-    // Click the row containing the strength pill (button has an "→" sibling)
-    const arrows = screen.queryAllByText("→");
-    if (arrows.length === 0) return;
-    // The strength row's parent has the click handler. Walk up to find it.
-    fireEvent.click(arrows[0].closest("[role='dialog']") ? arrows[0].parentElement.parentElement : arrows[0]);
-    if (onPick.mock.calls.length === 0) return; // tap didn't land — that's fine for this loose check
-    expect(typeof onPick.mock.calls[0][0]).toBe("string");
-    expect(onPick.mock.calls[0][0]).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    // The arrow is the affordance on a "log" row
+    fireEvent.click(screen.getByText("→"));
+    expect(onPick).toHaveBeenCalledTimes(1);
+    expect(onPick.mock.calls[0][0]).toBe("2026-06-13");
+  });
+
+  it("dismisses a row in place when Mark ✓ is tapped (instant feel)", () => {
+    render(
+      <RetroPickerSheet
+        untickedDays={[z2Row("2026-06-12"), strengthRow("2026-06-13")]}
+        pendingDraft={null}
+        onPick={() => {}}
+        onTickDate={() => {}}
+        onClose={() => {}}
+      />
+    );
+    expect(screen.getByText("2 unmarked days")).toBeTruthy();
+    fireEvent.click(screen.getByText("Mark ✓"));
+    // Visible state immediately reflects 1 row, even before the parent rerender
+    expect(screen.getByText("1 unmarked day")).toBeTruthy();
+  });
+
+  it("disables rows when pendingDraft is present", () => {
+    const onTickDate = vi.fn();
+    render(
+      <RetroPickerSheet
+        untickedDays={[z2Row("2026-06-12")]}
+        pendingDraft={{ draft: {}, ageMs: 1000, setCount: 1 }}
+        onPick={() => {}}
+        onTickDate={onTickDate}
+        onClose={() => {}}
+      />
+    );
+    // No tappable affordance rendered when a draft is in progress
+    expect(screen.queryByText("Mark ✓")).toBeNull();
+    expect(screen.getByText("Finish your live session first")).toBeTruthy();
   });
 });

--- a/tests/programme.test.js
+++ b/tests/programme.test.js
@@ -1134,10 +1134,14 @@ describe("hasMissedStrength / hasUntickedRecent — surface logic", () => {
         return { type: "rest", s: "Re" };
       });
 
-      // With weekDone empty → yesterday's z2 isn't ticked → should fire
+      // dayDone is date-keyed now — derive yesterday's date once for the
+      // both cases. With dayDone empty, the z2 row should surface.
+      const y = yesterday.getFullYear(), m = String(yesterday.getMonth()+1).padStart(2,"0"), d = String(yesterday.getDate()).padStart(2,"0");
+      const yDate = `${y}-${m}-${d}`;
+
       expect(hasUntickedRecent([], 3, {}, { week })).toBe(true);
-      // With weekDone[yIdx] = true → ticked → shouldn't fire on z2 alone
-      expect(hasUntickedRecent([], 3, { [yIdx]: true }, { week })).toBe(false);
+      // Marked via the new date-keyed store → ticked → no fire.
+      expect(hasUntickedRecent([], 3, { [yDate]: true }, { week })).toBe(false);
     } finally {
       vi.useRealTimers();
     }
@@ -1152,12 +1156,14 @@ describe("hasMissedStrength / hasUntickedRecent — surface logic", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-15T10:00:00")); // Mon
     try {
+      // Strength ONLY on Thursday so the window-cutoff is the variable
+      // under test — no other day triggers a non-strength tick path.
       const week = [
-        { type: "strength", s: "M" },   // Mon
-        { type: "rest",     s: "T" },
-        { type: "strength", s: "W" },
+        { type: "rest",     s: "M"  },
+        { type: "rest",     s: "T"  },
+        { type: "rest",     s: "W"  },
         { type: "strength", s: "Th" },  // last Thu = the missed session
-        { type: "cardio",   s: "F" },   // user swapped here
+        { type: "rest",     s: "F"  },
         { type: "rest",     s: "Sa" },
         { type: "rest",     s: "Su" },
       ];


### PR DESCRIPTION
User's report: "first Monday the link's missing" + "make this feel
slick, ballerina lean, predictable and frustration-free" + "editing
schedule turned a cardio tick into strength completed."

All three pointed at the same root cause: weekDone was keyed by
weekday-of-current-week, conflating two completion events that have
nothing to do with each other.

Architecture: two stores, never mixed
-------------------------------------
- HISTORY  — strength completion proof. A real session record exists
             for that date. Auto-managed by the live finalise +
             retro-submit paths.
- dayDone  — non-strength completion proof. Manual Mark ✓ via the
             home button or the picker.

findUntickedRecent picks the right store BY SCHEDULE TYPE for each
date:
  schedule says strength → history-backed only
  schedule says non-rest → dayDone-backed only
  schedule says rest     → not surfaced

Editing the schedule never silently promotes a cardio tick into a
strength completion. They live in different stores and reflect
different real-world events.

P.markDateDone(name, "YYYY-MM-DD") is the new primary write. The
old idx-based P.markDayDone is kept as a back-compat alias that
resolves idx → today's date in the current week, so existing
callers (the home "Mark complete" button) keep working unchanged.
P.getWeekDone is now a projection over dayDone for the home week
strip — derived data, no separate storage.

Picker UX — ballerina-lean
--------------------------
- Parent passes the pre-computed untickedDays list. Picker is a
  pure view; no internal findRecentDays, no past-week guard.
- Title shows the count: "2 unmarked days" / "1 unmarked day".
- Each row: one tap, one action. Strength → log via retro sheet.
  Non-strength → Mark ✓ writes dayDone[date], dismisses the row
  in place with a soft fade.
- When the visible list clears: "All caught up. Back to it."
  micro-celebration + auto-close after 1.1s.
- pendingDraft still disables tappability, with explicit copy —
  unchanged.

Home link
---------
"Missed a session? Log it →"  →  "{N} unmarked days — catch up →"
Always shows when N > 0, never when N === 0. Predictable.

349 tests, lint + typecheck + build clean.