### PR TITLE
Earned celebration on the catch-up picker — manual only

### DIFF
--- a/components/ForgeApp.jsx
+++ b/components/ForgeApp.jsx
@@ -4695,9 +4695,25 @@ export function RetroPickerSheet({untickedDays=[], pendingDraft, onPick, onTickD
 
         <div style={{display:"flex",flexDirection:"column",gap:8}}>
           {visible.length === 0 && (
-            <div style={{padding:"16px 4px 4px",fontSize:12,color:T.text3,fontStyle:"italic",fontFamily:T.serif,textAlign:"center",lineHeight:1.5}}>
-              Nothing pending.
-            </div>
+            // Two empty states, deliberately different:
+            //   - dismissed.size > 0: the user just cleared the list by
+            //     hand. A small celebratory beat — sage tick, italic
+            //     "Well kept." Acknowledges the discipline of honest
+            //     logging, not the act of clearing the list. No auto-
+            //     close; the user lingers as long as they want.
+            //   - dismissed.size === 0: opened to an already-empty list.
+            //     Neutral "Nothing pending." No reward for showing up to
+            //     a blank surface.
+            dismissed.size > 0 ? (
+              <div style={{padding:"22px 4px 6px",display:"flex",flexDirection:"column",alignItems:"center",gap:6}}>
+                <span style={{fontSize:18,color:T.sage,lineHeight:1}}>✓</span>
+                <span style={{fontSize:14,color:T.sage,fontStyle:"italic",fontFamily:T.serif,letterSpacing:"0.02em"}}>Well kept.</span>
+              </div>
+            ) : (
+              <div style={{padding:"16px 4px 4px",fontSize:12,color:T.text3,fontStyle:"italic",fontFamily:T.serif,textAlign:"center",lineHeight:1.5}}>
+                Nothing pending.
+              </div>
+            )
           )}
           {visible.map((row) => {
             const isLog = row.action === "log";

--- a/tests/components/RetroPickerSheet.test.jsx
+++ b/tests/components/RetroPickerSheet.test.jsx
@@ -113,12 +113,13 @@ describe("RetroPickerSheet — date-keyed catch-up", () => {
     expect(screen.getByText("Strength A")).toBeTruthy();
   });
 
-  it("does NOT auto-close or celebrate when the last row is dismissed", () => {
-    // The previous version popped a "Back to it" beat and auto-dismissed
-    // the sheet — that rewards CLEARING THE LIST which encourages
-    // speedrun-ticking even for days the user didn't actually train.
-    // Removed deliberately. After the last row, the dialog stays open
-    // with a quiet "Nothing pending." line; the close button is theirs.
+  it("celebrates when the user clears the list manually — but does NOT auto-close", () => {
+    // Two-tier empty state: clearing by hand earns a quiet "Well kept."
+    // beat (acknowledging the discipline of honest logging); opening to
+    // an empty list shows neutral "Nothing pending." Auto-close removed
+    // either way — the user closes when they're done, not when the
+    // screen decides for them. Eliminates the speedrun reward without
+    // losing the satisfaction of a job done.
     const onClose = vi.fn();
     render(
       <RetroPickerSheet
@@ -131,9 +132,26 @@ describe("RetroPickerSheet — date-keyed catch-up", () => {
     );
     fireEvent.click(screen.getByText("Yes — done"));
     expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByText("Well kept.")).toBeTruthy();
+    expect(screen.queryByText("Nothing pending.")).toBeNull();
     expect(screen.queryByText(/back to it/i)).toBeNull();
     expect(screen.queryByText(/all caught up/i)).toBeNull();
+  });
+
+  it("shows neutral 'Nothing pending.' when opened with no untickedDays", () => {
+    render(
+      <RetroPickerSheet
+        untickedDays={[]}
+        pendingDraft={null}
+        onPick={() => {}}
+        onTickDate={() => {}}
+        onClose={() => {}}
+      />
+    );
+    // No reward for opening to a blank surface — that would celebrate
+    // showing up, not doing the work.
     expect(screen.getByText("Nothing pending.")).toBeTruthy();
+    expect(screen.queryByText("Well kept.")).toBeNull();
   });
 
   it("disables rows when pendingDraft is present", () => {


### PR DESCRIPTION
User: "satisfying bit of polish to celebrate completing the exercises, but agree that it shouldn't be automatic. Rest sounds solid."

Two empty states, deliberately split:
- dismissed.size > 0 → small sage ✓ + italic "Well kept." A quiet acknowledgement of the discipline of honest logging. No timer, no "back to it" push — the user lingers as long as they want.
- dismissed.size === 0 → neutral "Nothing pending." No reward for opening to a blank surface (that would celebrate showing up instead of doing the work).

The polish lands on the act of honest review, not on list-clearance. The user closes when they're done. No auto-close, no scoreboard nudge.

351 tests, lint + typecheck clean.