### PR TITLE
Native motion polish — view transitions, scroll-timeline drum, header + lab arrival

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -71,3 +71,95 @@ input, button, textarea, select { font: inherit; }
       #131110;
   }
 }
+
+/* ─── Native motion polish (Safari 26+ / Chrome 115+) ──────────────────────
+   Four touches that lift the app from "web" to "native" without crossing
+   into skeuomorphism. Each gracefully no-ops on unsupported browsers
+   (rules just don't apply), so older Safari and SSR are unaffected.
+
+   1. View Transitions: cross-fade between screens. The JS side wraps
+      setScreen in document.startViewTransition (see ForgeApp.jsx).
+      Tuned to a 280ms Forge-ease curve — same easing as our other
+      motion (T.ease), so this swap reads as part of the same vocabulary.
+
+   2. Drum: each item's magnification is now CSS-driven via view-timeline,
+      not JS measuring scrollTop. The browser composites it smoothly on
+      every frame, no React work involved.
+
+   3. Home header: gentle scale + opacity dim on first 180px of scroll,
+      via the root scroll-timeline. "Moving past" the hero into content.
+
+   4. Performance Lab cards: each animates up + in as it crosses into
+      view (view-timeline per card). Replaces the all-at-once Fade
+      cascade with on-arrival motion that follows the eye.
+
+   prefers-reduced-motion: addressed at the end. All four collapse to
+   instant or none. */
+
+/* (1) View transitions — screen cross-fade */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 280ms;
+  animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* (2) Drum item magnification via view-timeline. The drum container is
+   the implicit scrollport (overflow:scroll, height:5×52px), so view(y)
+   runs each item from 0% (just entering at the bottom of the band) →
+   50% (centred) → 100% (just exiting at the top). Magnifies at the
+   middle, dims at the edges. Replaces the visibleIdx state-tracking
+   loop that fired on every onScroll. */
+@keyframes drum-item-focus {
+  0%   { transform: scale(0.68); opacity: 0.30; }
+  50%  { transform: scale(1.00); opacity: 1.00; }
+  100% { transform: scale(0.68); opacity: 0.30; }
+}
+.drum-item {
+  animation: drum-item-focus linear both;
+  animation-timeline: view(y);
+  will-change: transform, opacity;
+}
+
+/* (3) Home header compression. The "Forge / Squat & Push" headline and
+   its glow gently shrink + dim as the user scrolls into the day's session
+   card. Range capped at 180px so it's done before the user has scrolled
+   meaningfully — no lingering animation tying up frames. */
+@keyframes home-header-compress {
+  to { transform: scale(0.94) translateY(-6px); opacity: 0.72; }
+}
+.home-headline {
+  animation: home-header-compress linear both;
+  animation-timeline: scroll();
+  animation-range: 0 180px;
+  will-change: transform, opacity;
+}
+
+/* (4) Performance Lab card on-arrival. Each card lifts + fades as it
+   crosses into the viewport. animation-range "entry 0% entry 80%"
+   means the animation runs from the moment the card's leading edge
+   crosses into view, completing before the card is fully visible —
+   so the card is settled by the time the eye lands on it. */
+@keyframes lab-card-arrive {
+  from { transform: translateY(20px); opacity: 0; }
+  to   { transform: translateY(0);    opacity: 1; }
+}
+.lab-card {
+  animation: lab-card-arrive linear both;
+  animation-timeline: view();
+  animation-range: entry 0% entry 80%;
+}
+
+/* Reduced motion — all four collapse. View transitions become instant,
+   scroll-driven animations skip their animation entirely. Honours the
+   user's system setting; Forge's motion vocabulary stays intentional. */
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation-duration: 0.01ms;
+  }
+  .drum-item,
+  .home-headline,
+  .lab-card {
+    animation: none;
+  }
+}

--- a/components/ForgeApp.jsx
+++ b/components/ForgeApp.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import { flushSync } from "react-dom";
 import {
   WEEK, SESSIONS, deriveStrengthDaySessions,
   EXERCISE_POOLS, rotateAccessories, rotationDiff, pushHistoryBlock, computeRotationStimulusDelta,
@@ -131,22 +132,20 @@ function ScrollDrum({value,onChange,step=1.25,min=0,max=500,integer=false,label=
   const ref=useRef(null);
   const scrolling=useRef(false);
   const timer=useRef(null);
-  // Track the live scroll offset so the magnification can smoothly follow a
-  // flick (not just snap targets). visibleIdx is a fractional index that
-  // tracks the centre of the viewport during scroll; items compute their
-  // distance from it for opacity/scale ramps.
-  const [visibleIdx,setVisibleIdx]=useState(selectedIdx);
+  // Item magnification was a JS-driven onScroll + visibleIdx loop. As of
+  // Safari 26 / Chrome 115, CSS view-timeline does the same job natively
+  // and silkily — see `.drum-item` in globals.css. The onScroll handler
+  // here now only commits the value change (round to nearest snap-line);
+  // visual scaling is the compositor's job, not React's.
   useEffect(()=>{
     if(!ref.current||scrolling.current) return;
     const raf=requestAnimationFrame(()=>{ if(ref.current) ref.current.scrollTop=selectedIdx*ITEM_H; });
-    setVisibleIdx(selectedIdx);
     return()=>cancelAnimationFrame(raf);
   },[selectedIdx]);
   const onScroll=useCallback(()=>{
     if(!ref.current) return;
     scrolling.current=true;
     const frac=ref.current.scrollTop/ITEM_H;
-    setVisibleIdx(frac);
     const idx=Math.min(Math.round(frac),values.length-1);
     const next=values[Math.max(0,idx)];
     if(next!==undefined&&Math.abs(next-current)>(integer?0.1:0.01)) onChange(next);
@@ -158,9 +157,6 @@ function ScrollDrum({value,onChange,step=1.25,min=0,max=500,integer=false,label=
     const n=Math.round(v*100)/100;
     return Number.isInteger(n)?String(n):n.toFixed(2).replace(/0+$/,"").replace(/\.$/,"");
   };
-  // Inertia easing — cubic-bezier matches T.ease but with a softer overshoot
-  // so the magnify-on-arrival reads as a "settle" rather than a hard snap.
-  const drumEase = `cubic-bezier(0.18, 0.95, 0.30, 1.05)`;
   return (
     <div style={{display:"flex",flexDirection:"column",alignItems:"center",flex:1}}>
       {label&&<div style={{fontSize:10,fontWeight:500,color:T.text3,letterSpacing:"0.1em",textTransform:"uppercase",marginBottom:8}}>{label}</div>}
@@ -173,26 +169,11 @@ function ScrollDrum({value,onChange,step=1.25,min=0,max=500,integer=false,label=
         <div style={{position:"absolute",bottom:0,left:0,right:0,height:ITEM_H*1.8,background:`linear-gradient(to top,${T.bg2} 24%,transparent)`,pointerEvents:"none",zIndex:2}}/>
         <div ref={ref} onScroll={onScroll} style={{height:"100%",overflowY:"scroll",scrollSnapType:"y mandatory",WebkitOverflowScrolling:"touch",scrollbarWidth:"none",paddingTop:ITEM_H*half,paddingBottom:ITEM_H*half,boxSizing:"content-box"}}>
           <style>{`*::-webkit-scrollbar{display:none}`}</style>
-          {values.map((v,i)=>{
-            // Continuous distance from the live viewport centre. While
-            // settled, this equals integer distance from selectedIdx; mid-
-            // scroll it ramps smoothly so the drum reads as a single piece
-            // of material rolling past, not 5 discrete snap-stops.
-            const dist=Math.abs(i-visibleIdx);
-            const clamped=Math.min(dist,2.2);
-            // Selected → 1.0 / 30px. ±1 row → ~0.86 / ~25px. ±2 row → ~0.7 / ~19px.
-            const scale=Math.max(0.66,1-clamped*0.16);
-            const fontSize=Math.round(30-clamped*5.5);
-            const opacity=Math.max(0.28,1-clamped*0.36);
-            const colour=dist<0.6?T.text1:dist<1.4?T.text2:T.text4;
-            const weight=dist<0.6?400:300;
-            const textShadow=dist<0.4?`0 1px 14px ${T.coral}26`:"none";
-            return(
-              <div key={i} onClick={()=>onChange(v)} style={{height:ITEM_H,scrollSnapAlign:"center",display:"flex",alignItems:"center",justifyContent:"center",cursor:"pointer"}}>
-                <span style={{fontFamily:T.serif,fontSize,fontWeight:weight,color:colour,opacity,transform:`scale(${scale})`,textShadow,transition:`font-size 220ms ${drumEase}, color 200ms ${drumEase}, opacity 200ms ${drumEase}, transform 220ms ${drumEase}, text-shadow 240ms ${drumEase}`,userSelect:"none",willChange:"transform"}}>{fmt(v)}</span>
-              </div>
-            );
-          })}
+          {values.map((v,i)=>(
+            <div key={i} onClick={()=>onChange(v)} style={{height:ITEM_H,scrollSnapAlign:"center",display:"flex",alignItems:"center",justifyContent:"center",cursor:"pointer"}}>
+              <span className="drum-item" style={{fontFamily:T.serif,fontSize:30,fontWeight:400,color:T.text1,userSelect:"none"}}>{fmt(v)}</span>
+            </div>
+          ))}
         </div>
       </div>
       <div style={{fontFamily:T.serif,fontSize:12,fontWeight:300,color:T.text3,marginTop:8,fontStyle:"italic"}}>{unit ?? (integer?"reps":"kg")}</div>
@@ -325,10 +306,27 @@ export default function ForgeApp(){
     return P.getActive() !== null;
   });
   const [streak,setStreak]=useState(0); // retained for compat — now derived from history, see useMemo below
-  const [screen,setScreen]=useState(()=>{
+  const [screen,setScreenRaw]=useState(()=>{
     if (typeof window === "undefined") return "home";
     return LS.get("forge:onboarded", false) ? "home" : "onboarding";
   });
+  // Screen swap wrapped in the View Transitions API where supported (Safari
+  // 18.2+, Chrome 111+). On unsupported runtimes (older Safari, jsdom in
+  // tests, SSR) this falls straight through to a plain setState — no
+  // behaviour change, just a cinematic cross-fade where the platform lets
+  // us. flushSync forces React to commit the state change inside the
+  // callback so the browser can snapshot before/after frames; without it,
+  // React 19's deferred batching would skip the transition entirely.
+  //
+  // Reduced-motion users: prefers-reduced-motion is honoured at the CSS
+  // layer (transitions duration → 0) so the swap still happens, instantly.
+  const setScreen = useCallback((next) => {
+    if (typeof document === "undefined" || !document.startViewTransition) {
+      setScreenRaw(next);
+      return;
+    }
+    document.startViewTransition(() => flushSync(() => setScreenRaw(next)));
+  }, []);
   const [activeSessionIdx,setActiveSessionIdx]=useState(0);
   const [sessionSwaps,setSessionSwaps]=useState({});
   const [programmeBlock,setProgrammeBlock]=useState(()=>PB.get());
@@ -777,7 +775,7 @@ export default function ForgeApp(){
     if (activeProfile) {
       backgroundSync(activeProfile, { onUpdate: handleSyncUpdate });
     }
-  }, [activeProfile, handleSyncUpdate]);
+  }, [activeProfile, handleSyncUpdate, setScreen]);
 
   const activateProfile = async (name, { claim = false } = {}) => {
     const trimmed = String(name).trim();
@@ -952,7 +950,7 @@ export default function ForgeApp(){
     setRestTrigger({id:Date.now(),duration:block.rest});
     setSsRoundDone(false);
     setAwaitRpe(false);
-  },[block,blockIdx,isSS,setNum,activeSession,resolveExFn,pushSetToDraft]);
+  },[block,blockIdx,isSS,setNum,activeSession,resolveExFn,pushSetToDraft,setScreen]);
 
   const handleLog=useCallback(()=>{
     if(isSS){
@@ -976,7 +974,7 @@ export default function ForgeApp(){
       return;
     }
     setAwaitRpe(true);
-  },[block,blockIdx,isSS,phase,setNum,activeSession,resolveExFn,pushSetToDraft]);
+  },[block,blockIdx,isSS,phase,setNum,activeSession,resolveExFn,pushSetToDraft,setScreen]);
 
   // Jump to a specific block in the active session. Used by the session
   // overview sheet when a busy gym means the user needs to do exercises in
@@ -3108,9 +3106,12 @@ function HomeScreen({rhythm,profileName,userWeek,strengthDaySessions,onEditWeek,
         )}
       </Fade>
 
-      {/* Day headline — driven by viewIdx */}
+      {/* Day headline — driven by viewIdx. className="home-headline" hooks
+          the scroll-timeline compression in globals.css: gentle scale +
+          opacity dim over the first 180px of scroll, so the hero feels
+          like something you're moving past, not stranded above content. */}
       <Fade d={100}>
-        <div style={{padding:"28px 24px 0"}}>
+        <div className="home-headline" style={{padding:"28px 24px 0"}}>
           {/* "Today" / "Tomorrow" / day-name label row */}
           <div style={{display:"flex",alignItems:"center",gap:10,marginBottom:10}}>
             <div style={{

--- a/components/PerformanceLab.jsx
+++ b/components/PerformanceLab.jsx
@@ -143,7 +143,7 @@ function EmptyState() {
 const LAB_CARD_SHADOW = "inset 0 1px 0 rgba(237,235,231,0.04), 0 1px 2px rgba(10,9,8,0.28), 0 10px 28px -16px rgba(10,9,8,0.5)";
 function Card({ title, subtitle, children }) {
   return (
-    <div style={{margin:"24px 24px 0", background:T.bg2, border:`1px solid ${T.bg3}`, borderRadius:T.r.lg, overflow:"hidden", boxShadow:LAB_CARD_SHADOW}}>
+    <div className="lab-card" style={{margin:"24px 24px 0", background:T.bg2, border:`1px solid ${T.bg3}`, borderRadius:T.r.lg, overflow:"hidden", boxShadow:LAB_CARD_SHADOW}}>
       <div style={{padding:"18px 20px 14px", borderBottom:`1px solid ${T.bg3}`}}>
         <div style={{fontSize:10, fontWeight:500, color:T.text3, letterSpacing:"0.12em", textTransform:"uppercase", marginBottom:4}}>{title}</div>
         {subtitle && <div style={{fontFamily:T.serif, fontSize:15, fontWeight:300, color:T.text2, fontStyle:"italic"}}>{subtitle}</div>}


### PR DESCRIPTION
Four CSS-driven moves, all gracefully no-op on unsupported runtimes (older
Safari, jsdom, SSR). Light touch — subtle, in-vocabulary, no skeuomorphism.

1. View transitions on screen swap
   - setScreen wrapped in document.startViewTransition + flushSync so
     React 19's deferred batching doesn't skip the transition.
   - 280ms cross-fade tuned to T.ease (cubic-bezier(0.22, 1, 0.36, 1)) —
     same curve as our other motion vocabulary.
   - Home → readiness → session → done reads as one continuous app, not
     a sequence of hard re-renders. Falls through to plain setState on
     Safari <18.2 or environments without document.startViewTransition.

2. Drum item magnification: scroll-timeline replaces JS measurement
   - Removed visibleIdx state + onScroll-driven distance math (the
     fractional-index loop that fired per scroll tick).
   - .drum-item gets `animation-timeline: view(y)`; the browser
     composites the scale+opacity ramp per frame, no React work.
   - onScroll handler keeps the value-change-and-snap logic; ONLY
     visual scaling moved to CSS.
   - ~25 lines of JS → 6 lines of CSS keyframes. Smoother on the
     compositor thread.

3. Home headline compression
   - .home-headline animates scale 1 → 0.94 + translateY 0 → -6px +
     opacity 1 → 0.72 over the first 180px of root scroll.
   - The hero "moves past" rather than sitting stranded as you scroll
     into the day's session card. Done before meaningful scroll, no
     frames tied up below.

4. Performance Lab cards arrive on-scroll
   - .lab-card per-card view-timeline replaces the all-at-once Fade
     d={N} cascade.
   - Animation-range: entry 0% entry 80% — card settles BEFORE the
     eye lands on it, so reading feels continuous, not flickery.

prefers-reduced-motion respected: view transitions duration → 0.01ms,
the three scroll-driven animations switch to `animation: none`. Forge's
motion vocabulary stays intentional for users who've opted out.

351 tests, lint + typecheck + build clean.