### PR TITLE
Motion polish — fix cross-fade flicker + restore iOS bounce

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,10 +3,10 @@ html, body {
   height: 100%;
   background: #131110;
   overflow-x: hidden;
-  /* Kill the rubber-band-the-whole-page tell. Sheets each carry their own
-     overscroll-behavior:contain so an inner scroll stops cleanly at its
-     ends; this catches the root case for any non-sheet scrolling. */
-  overscroll-behavior-y: none;
+  /* No overscroll-behavior on the root — the native iOS rubber-band on
+     the page itself is part of the platform feel and users miss it when
+     it's gone. Sheet scrims keep their own `overscroll-behavior: contain`
+     so scrolling inside a sheet doesn't bleed into the page behind. */
 }
 body { -webkit-tap-highlight-color: transparent; font-family: var(--font-dm-sans), sans-serif; }
 input, button, textarea, select { font: inherit; }
@@ -96,11 +96,19 @@ input, button, textarea, select { font: inherit; }
    prefers-reduced-motion: addressed at the end. All four collapse to
    instant or none. */
 
-/* (1) View transitions — screen cross-fade */
+/* (1) View transitions — screen cross-fade.
+   mix-blend-mode: plus-lighter is the canonical fix for the perceived
+   midpoint dim ("flicker"). By default the old layer fades out and the
+   new layer fades in simultaneously, so at ~50% progress both layers sit
+   at ~0.5 opacity. With a normal blend the dark body shows through the
+   transparency and the eye reads a dim. plus-lighter adds the two layers'
+   premultiplied alpha so the composite stays at full brightness throughout
+   — the cross-fade reads as a soft swap, not a dip-to-black-and-back. */
 ::view-transition-old(root),
 ::view-transition-new(root) {
   animation-duration: 280ms;
   animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+  mix-blend-mode: plus-lighter;
 }
 
 /* (2) Drum item magnification via view-timeline. The drum container is


### PR DESCRIPTION
Two follow-up fixes from real-device testing on iOS 26.6:

1. Cross-fade flicker (home ↔ Performance Lab)
   - The default view-transition fades old and new layers
     simultaneously, so at ~50% progress both sit at ~0.5 opacity.
     With a normal blend the dark body (#131110) shows through the
     transparency and the eye reads a momentary dim.
   - Fix: mix-blend-mode: plus-lighter on both ::view-transition-old(root)
     and ::view-transition-new(root). The compositor adds the two
     layers' premultiplied alpha so brightness stays constant through
     the swap. Canonical fix, no perf cost.

2. Lost iOS rubber-band on the page
   - Previous depth-pass added `overscroll-behavior-y: none` on html/body
     intending to kill the "rubber-band-the-whole-page tell." It also
     killed the genuine native bounce on the page itself, which is part
     of the platform feel users miss when it's gone.
   - Fix: drop the body-level rule entirely. Sheet scrims keep their
     own `overscroll-behavior: contain` so scrolling INSIDE a sheet
     doesn't bleed into the page behind — that was the actual problem
     we needed to solve. The native bounce on the page is back.

351 tests, lint + typecheck + build clean.