### PR TITLE
Add timed exercise support and improve grain overlay visibility

### DIFF
--- a/components/ForgeApp.jsx
+++ b/components/ForgeApp.jsx
@@ -95,7 +95,25 @@ function weightStepForLoadType(lt) {
   return 1.25;  // barbell / external default
 }
 
-// ─── loadType → caption ──────────────────────────────────────────────────────
+// Detect a "timed" prescription string like "20s", "30sec", "1m". Returns
+// either { seconds: 20 } for a parseable duration or null for everything
+// else. Lets the session screen show "20s · hold" instead of "20 reps",
+// and lets the drum edit overlay swap its unit to seconds. The string
+// form lives in the pool data (L-Sit Hold reps:"20s"); when a user
+// overrides via the drum we store an integer alongside — same shape as
+// numeric reps — and treat it as seconds whenever the prescribed value
+// was originally timed.
+function parseTimedReps(reps) {
+  if (typeof reps !== "string") return null;
+  const m = reps.trim().match(/^(\d+)\s*(s|sec|second|seconds|m|min|minute|minutes)$/i);
+  if (!m) return null;
+  const n = parseInt(m[1], 10);
+  const unit = m[2].toLowerCase();
+  const seconds = unit.startsWith("m") ? n * 60 : n;
+  return { seconds };
+}
+
+
 // What does the number the user types represent? Resolves the per-DB vs
 // total-load ambiguity the picker has historically left implicit. Two
 // vocabularies coexist: programme.js entries carry "barbell"/"per_db"/
@@ -4081,11 +4099,23 @@ function SessionScreen({session,block,blockIdx,totalBlocks,setNum,phase,isSS,act
             )}
           </>
         )}
-        <div style={{display:"flex",alignItems:"baseline",gap:6,cursor:"pointer",userSelect:"none"}} onClick={()=>{ if(activeEx?.name) setEditTarget({exName:activeEx.name,currentKg:showWeightPicker?currentW:null,currentReps:getR(activeEx),loadType}); }}>
-          <span style={{fontFamily:T.serif,fontSize:48,fontWeight:400,color:T.coral,lineHeight:1,fontStyle:"italic"}}>{getR(activeEx)}</span>
-          <span style={{fontSize:14,color:T.text3,marginBottom:4}}>reps</span>
-          <span style={{fontSize:11,color:T.text3,marginBottom:6,marginLeft:4}}>↕</span>
-        </div>
+        {/* "reps" label is wrong for timed exercises (e.g. L-Sit Hold,
+            prescribed as "20s"). Read the ORIGINAL prescribed value (not
+            getR, which folds in any drum override that may have stamped
+            an integer over the string). If timed, render "Xs · hold"
+            instead of "X reps". The drum overlay also knows from this
+            (target.timed) so its unit switches to seconds. */}
+        {(() => {
+          const timed = parseTimedReps(activeEx?.reps);
+          const displayVal = getR(activeEx);
+          return (
+            <div style={{display:"flex",alignItems:"baseline",gap:6,cursor:"pointer",userSelect:"none"}} onClick={()=>{ if(activeEx?.name) setEditTarget({exName:activeEx.name,currentKg:showWeightPicker?currentW:null,currentReps:displayVal,loadType,timed:!!timed}); }}>
+              <span style={{fontFamily:T.serif,fontSize:48,fontWeight:400,color:T.coral,lineHeight:1,fontStyle:"italic"}}>{timed ? `${typeof displayVal === "number" ? displayVal : timed.seconds}s` : displayVal}</span>
+              <span style={{fontSize:14,color:T.text3,marginBottom:4}}>{timed ? "hold" : "reps"}</span>
+              <span style={{fontSize:11,color:T.text3,marginBottom:6,marginLeft:4}}>↕</span>
+            </div>
+          );
+        })()}
         {/* Phase 3 — quiet "deload · day N of M" subtitle in muted gold.
             Only renders during an active deload window. */}
         {deloadDayTag && (
@@ -4603,7 +4633,16 @@ function DrumEditOverlay({target,workingWeights,setWW,workingReps,setWR,block,on
   const ex=block.type==="main"?block.ex:(target.exName===block.exA?.name?block.exA:block.exB);
   const initKg  =workingWeights[target.exName]??ex?.weight??0;
   const rawReps =workingReps[target.exName]??ex?.reps;
-  const initReps=typeof rawReps==="string"?8:(rawReps??8);
+  // Timed exercises (L-Sit Hold prescribed "20s") seed from the parsed
+  // seconds, not a default 8/20. Without this the drum opens at "8 reps"
+  // for a 20-second hold, the user confirms, and the prescription is
+  // silently stamped over with an integer that's then treated as reps
+  // everywhere downstream. target.timed is set by the session-screen
+  // dispatcher when the prescribed value parses as a duration.
+  const timedSeed = target.timed ? parseTimedReps(ex?.reps)?.seconds : null;
+  const initReps = typeof rawReps==="string"
+    ? (timedSeed ?? 8)
+    : (rawReps ?? timedSeed ?? 8);
   const [kg,setKg]    =useState(initKg);
   const [reps,setReps]=useState(initReps);
   const hasWeight=ex?.weight!==null&&ex?.weight!==undefined;
@@ -4625,7 +4664,7 @@ function DrumEditOverlay({target,workingWeights,setWW,workingReps,setWR,block,on
         </div>
         <div style={{display:"flex",gap:16,justifyContent:hasWeight?"space-between":"center"}}>
           {hasWeight&&<ScrollDrum value={kg} onChange={setKg} step={weightStep} min={0} max={400} label={lt==="per_db"?"kg / db":"kg"}/>}
-          <ScrollDrum value={reps} onChange={setReps} step={1} min={1} max={30} integer label="reps"/>
+          <ScrollDrum value={reps} onChange={setReps} step={target.timed?5:1} min={target.timed?5:1} max={target.timed?180:30} integer label={target.timed?"sec":"reps"} unit={target.timed?"sec":undefined}/>
         </div>
         <button onClick={()=>{
           if(hasWeight) setWW(p=>({...p,[target.exName]:kg}));

--- a/components/GrainOverlay.jsx
+++ b/components/GrainOverlay.jsx
@@ -34,11 +34,19 @@ export default function GrainOverlay() {
         inset: 0,
         pointerEvents: "none",
         zIndex: 1,
-        opacity: 0.05,
-        mixBlendMode: "overlay",
+        // mix-blend-mode: overlay at 5% opacity on a near-black background
+        // (#131110) is mathematically near-invisible — the dark base
+        // dominates and the texture vanishes. mix-blend-mode: screen lifts
+        // the grain on dark surfaces (light grain becomes visible noise);
+        // opacity raised from 0.05 to 0.12 so it actually reads on a
+        // high-density display. Still textural — visible on flat fields,
+        // recedes against any content. Smaller tile (192px → richer
+        // density) so the noise pattern doesn't read as wallpaper.
+        opacity: 0.12,
+        mixBlendMode: "screen",
         backgroundImage: `url("data:image/svg+xml,${GRAIN_SVG}")`,
         backgroundRepeat: "repeat",
-        backgroundSize: "256px 256px",
+        backgroundSize: "192px 192px",
       }}
     />
   );

--- a/lib/programme.js
+++ b/lib/programme.js
@@ -158,7 +158,11 @@ export const EXERCISE_POOLS = {
     { name:"Incline Landmine Press",       reps:10, weight:22,  muscle:"Upper chest",     vid:"N9_1DnqUAQw", loadType:"barbell", loadProfile:"moderate_mid_rep" },
     { name:"Landmine Squeeze Press", reps:12,      weight:22,  muscle:"Upper chest",      vid:"1G-_FTEkoNw", loadType:"barbell", loadProfile:"moderate_mid_rep" },
     { name:"Kneeling Landmine Press", reps:10,     weight:22,  muscle:"Upper chest",      vid:"39lH32_Ukos", loadType:"barbell", loadProfile:"moderate_mid_rep" },
-    { name:"Floor Press",            reps:10,      weight:45,  muscle:"Upper chest",      vid:"L1BKVBQNc9g", loadType:"barbell", loadProfile:"moderate_mid_rep" },
+    // Floor Press intentionally removed from this slot — same horizontal-
+    // push pattern as Barbell Bench Press (the day's main lift), so a
+    // rotation roll into Floor Press here produces two near-identical
+    // movements in the same session. It stays in SWAP_DB["Barbell Bench
+    // Press"] so users can still substitute it for Bench explicitly.
   ]},
   "afin-A":{ gripDemand:"HIGH", zone:"bodyweight", loadProfile:"light_high_rep", pool:[
     { name:"Hanging Leg Raise",      reps:10,      weight:null,muscle:"Core",              vid:"Pr1ieGZ5atk", loadType:"bodyweight", loadProfile:"light_high_rep" },


### PR DESCRIPTION
## Summary
This PR adds support for timed exercises (e.g., "L-Sit Hold" prescribed as "20s") throughout the session and drum edit flows, and improves the visibility of the grain texture overlay on dark backgrounds.

## Key Changes

- **Timed Exercise Parsing**: Added `parseTimedReps()` function to detect and parse duration strings like "20s", "30sec", "1m" into seconds, enabling proper display and editing of time-based prescriptions.

- **Session Screen Display**: Updated the reps display to show "Xs · hold" instead of "X reps" for timed exercises, with the label dynamically switching based on whether the exercise is timed.

- **Drum Edit Overlay**: 
  - Modified initialization logic to seed timed exercises from their prescribed duration rather than defaulting to 8 reps
  - Changed the reps drum to use 5-second increments (step: 5) with a range of 5–180 seconds for timed exercises
  - Updated the label and unit display to show "sec" instead of "reps" when editing timed exercises

- **Grain Overlay Enhancement**: 
  - Changed `mix-blend-mode` from "overlay" to "screen" for better visibility on dark backgrounds
  - Increased opacity from 0.05 to 0.12 to make the texture readable on high-density displays
  - Reduced `backgroundSize` from 256px to 192px for richer texture density

- **Exercise Pool**: Removed "Floor Press" from the upper chest rotation pool with a comment explaining it duplicates the horizontal-push pattern of Barbell Bench Press (the day's main lift), while keeping it available as an explicit swap option.

## Implementation Details

- The `target.timed` flag is passed through the edit dispatcher to coordinate behavior between the session screen and drum overlay
- Timed exercises preserve the original prescribed string value while allowing numeric overrides to be stored and treated as seconds
- The grain texture now uses "screen" blend mode which lifts the grain visibility on dark surfaces while remaining subtle against content

https://claude.ai/code/session_01Gucgxvub2JW5XT1q9dhU8f