### PR TITLE
Rehydration: schedule, focus, and ticks now survive reinstall

### DIFF
--- a/components/ForgeApp.jsx
+++ b/components/ForgeApp.jsx
@@ -541,6 +541,28 @@ export default function ForgeApp(){
   // commit a new week and have the home strip / retro / done screens reflow
   // without a reload. Falls back to the default WEEK when nothing is stored.
   const [userWeek, setUserWeek] = useState(() => W.get() || WEEK);
+
+  // Push the current local user-state to blob. Called whenever a user-
+  // facing customisation changes (schedule edit, focus pick, day tick) so
+  // a different device — or a fresh install of this one — rehydrates with
+  // the latest. Without this every customisation lived only in localStorage
+  // and reinstalls reverted to defaults despite history coming back fine.
+  const pushUserStateSnapshot = useCallback(() => {
+    if (!activeProfile) return;
+    blobPush(activeProfile, {
+      meta: {
+        weights: P.getWeights(activeProfile),
+        reps: P.getReps(activeProfile),
+        streak: P.getStreak(activeProfile),
+        programmeBlock: PB.get(),
+        userWeek: W.get(),
+        userFocus: F.get(activeProfile),
+        dayDone: P.getDayDone(activeProfile),
+        bonusDone: P.getBonusDone(activeProfile),
+      },
+      history: H.get(activeProfile),
+    });
+  }, [activeProfile]);
   const strengthDaySessions = useMemo(() => deriveStrengthDaySessions(userWeek), [userWeek]);
   // Single source of truth for catch-up state. dayDone is date-keyed
   // (`{ "2026-06-13": true, ... }`) — strength session finalises write it,
@@ -558,11 +580,13 @@ export default function ForgeApp(){
     W.save(newWeek);
     setUserWeek(W.get() || WEEK); // re-read so state mirrors the persisted/normalised shape
     setWeekEditorOpen(false);
+    pushUserStateSnapshot();
   };
   const handleResetWeek = () => {
     W.reset();
     setUserWeek(WEEK);
     setWeekEditorOpen(false);
+    pushUserStateSnapshot();
   };
 
   // Seed on profile change: instant load from localStorage, background sync from blob
@@ -776,13 +800,25 @@ export default function ForgeApp(){
 
   // Reusable sync update handler — called when backgroundSync finds newer blob data.
   // Silently updates React state so the UI reflects the freshest data.
+  // The persistToLocal step inside backgroundSync has already written each
+  // field to localStorage; this just makes the running UI catch up without
+  // a reload.
   const handleSyncUpdate = useCallback(({ meta, history: remoteHistory }) => {
     if (meta?.weights) setWWState(meta.weights);
     if (meta?.reps) setWRState(meta.reps);
     if (meta?.streak?.count) setStreak(meta.streak.count);
     if (meta?.programmeBlock) setProgrammeBlock(meta.programmeBlock);
+    if (meta?.userWeek) setUserWeek(meta.userWeek);
+    if (meta?.userFocus) setUserFocus(meta.userFocus);
+    if (meta?.dayDone) {
+      setDayDone(meta.dayDone);
+      // weekDone is derived from dayDone — re-project after the new
+      // dayDone lands so the home strip updates in the same tick.
+      if (activeProfile) setWeekDone(P.getWeekDone(activeProfile));
+    }
+    if (meta?.bonusDone) setBonusDone(meta.bonusDone);
     if (remoteHistory?.length) setHistory(remoteHistory);
-  }, []);
+  }, [activeProfile]);
 
   // Open Performance Lab — triggers background sync first to hydrate from blob
   // if localStorage is stale (e.g. switching from PWA to Safari on same device).
@@ -1232,13 +1268,19 @@ export default function ForgeApp(){
 
       // Push both meta and the just-finalised record to blob.
       // History push is incremental — only this one record, the server
-      // merges with whatever it has.
+      // merges with whatever it has. Includes user-state fields so a
+      // session-complete push can't wipe a schedule/focus/tick the user
+      // changed mid-session.
       blobPush(activeProfile, {
         meta: {
           weights: workingWeights,
           reps: workingReps,
           streak: P.getStreak(activeProfile),
           programmeBlock,
+          userWeek: W.get(),
+          userFocus: F.get(activeProfile),
+          dayDone: P.getDayDone(activeProfile),
+          bonusDone: P.getBonusDone(activeProfile),
         },
         history: sessionRecord ? [sessionRecord] : [],
       });
@@ -1288,7 +1330,8 @@ export default function ForgeApp(){
       const newStreak = bumpStreak(activeProfile);
       setStreak(newStreak);
     }
-  },[activeProfile]);
+    pushUserStateSnapshot();
+  },[activeProfile, pushUserStateSnapshot]);
 
   // Mark today's optional cardio bonus complete. Separate store from weekDone;
   // deliberately does NOT bump the streak — bonuses are extras, not adherence.
@@ -1320,6 +1363,7 @@ export default function ForgeApp(){
     const stimulusDelta = computeRotationStimulusDelta(oldConfig, newConfig);
     setRotationSummary({ blockNumber: programmeBlock.number, changes, stimulusDelta });
     setFocusPickerOpen(false);
+    pushUserStateSnapshot();
   };
 
   if(!mounted) return null;
@@ -1807,9 +1851,20 @@ const sProps={
         });
       } catch {/* analytics never blocks */}
 
-      // Push to blob in background
+      // Push to blob in background. Same reasoning as the live-finalise
+      // path: carry the full user-state so a retro submit doesn't clobber
+      // schedule/focus/tick changes that happened on this device.
       blobPush(activeProfile, {
-        meta: { weights: workingWeights, reps: workingReps },
+        meta: {
+          weights: workingWeights,
+          reps: workingReps,
+          streak: P.getStreak(activeProfile),
+          programmeBlock,
+          userWeek: W.get(),
+          userFocus: F.get(activeProfile),
+          dayDone: P.getDayDone(activeProfile),
+          bonusDone: P.getBonusDone(activeProfile),
+        },
         history: H.get(activeProfile),
       });
 

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -413,6 +413,12 @@ function _handleOnline() {
         reps: P.getReps(profile),
         streak: P.getStreak(profile),
         programmeBlock: PB.get(),
+        // Cross-device-survivable user state — see getLocalProfile and the
+        // merge logic for the contract on each.
+        userWeek: W.get(),
+        userFocus: F.get(profile),
+        dayDone: P.getDayDone(profile),
+        bonusDone: P.getBonusDone(profile),
       },
       history: H.get(profile),
     }));
@@ -482,6 +488,16 @@ function mergeProfileData(local, remote) {
   // - Weights/reps: union of keys, remote wins ties (more recent device)
   // - Streak: higher count wins
   // - ProgrammeBlock: higher block number wins
+  // - userWeek: remote wins iff present. The schedule is single-user intent,
+  //   not deltas — preserving local-null when remote has it would silently
+  //   blow away a schedule the user just rehydrated from blob (e.g. fresh
+  //   install case). Local override (null = "use default") is treated as
+  //   "no opinion."
+  // - userFocus: remote wins iff present. Same intent-not-deltas logic.
+  // - dayDone: union of keys. Either device marking a date done means it
+  //   stays done — the operation is monotonic so unions are safe.
+  // - bonusDone: union of keys, then prune to the current week (bonusDone
+  //   is per-week scoped; old weeks aren't useful and just bloat the blob).
   // - History: union by id, sorted chronologically
   const mergedMeta = {
     weights: { ...localMeta.weights, ...(remoteMeta.weights || {}) },
@@ -492,6 +508,10 @@ function mergeProfileData(local, remote) {
     programmeBlock: (remoteMeta.programmeBlock?.number || 0) >= (localMeta.programmeBlock?.number || 0)
       ? (remoteMeta.programmeBlock || localMeta.programmeBlock)
       : localMeta.programmeBlock,
+    userWeek: remoteMeta.userWeek ?? localMeta.userWeek ?? null,
+    userFocus: remoteMeta.userFocus ?? localMeta.userFocus ?? null,
+    dayDone: { ...(localMeta.dayDone || {}), ...(remoteMeta.dayDone || {}) },
+    bonusDone: { ...(localMeta.bonusDone || {}), ...(remoteMeta.bonusDone || {}) },
     displayName: remoteMeta.displayName || localMeta.displayName,
   };
   const mergedHistory = H.merge(localHistory, remoteHistory);
@@ -513,6 +533,17 @@ export function getLocalProfile(profile) {
       reps: P.getReps(profile),
       streak: P.getStreak(profile),
       programmeBlock: PB.get(),
+      // Survivable across a fresh install: edited schedule (W), focus
+      // identity (F), and the non-strength tick stores (dayDone / bonusDone).
+      // Without these in meta, a user who reinstalls Forge gets history
+      // back but loses every customisation — schedule reverts to default,
+      // focus drops to Forged, and all manual "yes I did this" ticks
+      // disappear. Pulled from the same per-profile stores that the
+      // ForgeApp hydration path reads on load.
+      userWeek: W.get(),
+      userFocus: F.get(profile),
+      dayDone: P.getDayDone(profile),
+      bonusDone: P.getBonusDone(profile),
     },
     history: H.get(profile),
   };
@@ -524,6 +555,20 @@ function persistToLocal(profile, { meta, history }) {
   P.saveReps(profile, meta.reps || {});
   if (meta.streak) P.saveStreak(profile, meta.streak);
   if (meta.programmeBlock) PB.save(meta.programmeBlock);
+  // Hydrate user-state stores from the merged meta so a fresh install
+  // (or any device whose localStorage is colder than blob) actually picks
+  // up the schedule + focus + tick-marks. Each save call is guarded —
+  // an empty meta field shouldn't blow away local data that's richer.
+  if (meta.userWeek) {
+    try { W.save(meta.userWeek); } catch { /* invalid shape — ignore */ }
+  }
+  if (meta.userFocus) F.save(profile, meta.userFocus);
+  if (meta.dayDone && Object.keys(meta.dayDone).length > 0) {
+    LS.set(`forge:${profile}:dayDone`, meta.dayDone);
+  }
+  if (meta.bonusDone && Object.keys(meta.bonusDone).length > 0) {
+    LS.set(`forge:${profile}:bonusDone:${weekKey()}`, meta.bonusDone);
+  }
   H.save(profile, history || []);
 }
 


### PR DESCRIPTION
User reported: deleted and reinstalled Forge, login worked, history came back, but custom schedule edits + non-strength tick marks were gone — had to redo the schedule and re-mark completed workouts.

Root cause: blob sync's meta payload only carried weights, reps, streak, and programmeBlock. The four user-state stores
  - W (custom weekly schedule)
  - F (training focus identity)
  - dayDone (date-keyed non-strength tick marks)
  - bonusDone (cardio bonus ticks, per-week) lived only in localStorage. On reinstall, localStorage is empty and nothing in the blob restored these stores, so the user got defaults back despite the rest of their data rehydrating fine.

Three-part fix:

1. lib/storage.js — read + merge + write the new fields
   - getLocalProfile() and _handleOnline() include the four stores in the meta payload they construct.
   - mergeProfileData() applies a per-field merge rule: · userWeek/userFocus: remote wins iff present (intent, not deltas — preserving local-null when remote has it would clobber a fresh-install rehydrate) · dayDone/bonusDone: union of keys (monotonic — once done, stays done — so union is safe across devices)
   - persistToLocal() hydrates W, F, dayDone, bonusDone into localStorage from the merged meta so a fresh device picks them up.

2. components/ForgeApp.jsx — push on every user-state mutation
   - New pushUserStateSnapshot() helper builds the canonical payload from current local state.
   - handleSaveWeek / handleResetWeek / handleSaveFocus / handleMarkDayDone all call it after their respective write — so a schedule edit or tick on one device propagates to blob immediately, not just on next session-complete.
   - The two session-finalise blobPush sites (live commitLog and retro submit) now carry the user-state fields too, so a session-complete can't silently clobber a mid-session schedule edit with stale data.
   - handleSyncUpdate also hydrates the four fields into React state when an incoming blob update arrives, so a fresh-install device's UI catches up without a reload. weekDone re-projects from the new dayDone in the same tick.

351 tests, lint + typecheck + build clean.