### PR TITLE
Full sync coverage — bodyweight, training state, push-on-rotation, pu…

### DIFF
--- a/components/ForgeApp.jsx
+++ b/components/ForgeApp.jsx
@@ -559,6 +559,8 @@ export default function ForgeApp(){
         userFocus: F.get(activeProfile),
         dayDone: P.getDayDone(activeProfile),
         bonusDone: P.getBonusDone(activeProfile),
+        bodyweight: BW.getRaw(activeProfile),
+        trainingState: TS.get(activeProfile),
       },
       history: H.get(activeProfile),
     });
@@ -817,6 +819,16 @@ export default function ForgeApp(){
       if (activeProfile) setWeekDone(P.getWeekDone(activeProfile));
     }
     if (meta?.bonusDone) setBonusDone(meta.bonusDone);
+    // Bodyweight + trainingState arrived from blob — reflect into React
+    // state so BW-progression slots and the engine read the freshly-merged
+    // values without a reload. persistToLocal has already written to LS;
+    // this just refreshes the UI in the same tick as the other fields.
+    if (meta?.bodyweight?.kg != null) setBodyweightState(meta.bodyweight.kg);
+    if (meta?.trainingState && activeProfile) {
+      const ts = meta.trainingState;
+      setActiveDeload(ts?.mesocycle?.activeDeload || null);
+      try { setDeloadOffer(shouldOfferDeload(ts, H.get(activeProfile))); } catch {}
+    }
     if (remoteHistory?.length) setHistory(remoteHistory);
   }, [activeProfile]);
 
@@ -1341,7 +1353,8 @@ export default function ForgeApp(){
     const wm=[6,0,1,2,3,4,5];
     const idx=wm[dw];
     setBonusDone(P.markBonusDone(activeProfile,idx));
-  },[activeProfile]);
+    pushUserStateSnapshot();
+  },[activeProfile, pushUserStateSnapshot]);
 
   // Save the user's training focus + re-rotate accessories IMMEDIATELY with the
   // new bias. Keeps block number and startDate (the change is a re-pick, not
@@ -1458,6 +1471,13 @@ const sProps={
     };
     setProgrammeBlock(next);
     PB.save(next);
+    // Push immediately — the previous code only sync'd programmeBlock via
+    // the next session-finalise, so users who rotated and then reinstalled
+    // before training lost the new rotation. Also covers the case where
+    // session-complete fires later with a stale closure over programmeBlock
+    // (the closure captures `programmeBlock` from the render where the user
+    // rotated; pushing here pins the latest persisted state regardless).
+    pushUserStateSnapshot();
     if (showSummary) {
       setRotationSummary({
         blockNumber: next.number,

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -419,6 +419,8 @@ function _handleOnline() {
         userFocus: F.get(profile),
         dayDone: P.getDayDone(profile),
         bonusDone: P.getBonusDone(profile),
+        bodyweight: BW.getRaw(profile),
+        trainingState: TS.get(profile),
       },
       history: H.get(profile),
     }));
@@ -498,6 +500,14 @@ function mergeProfileData(local, remote) {
   //   stays done — the operation is monotonic so unions are safe.
   // - bonusDone: union of keys, then prune to the current week (bonusDone
   //   is per-week scoped; old weeks aren't useful and just bloat the blob).
+  // - bodyweight: latest-wins by updatedAt timestamp. A user weighing in on
+  //   one device shouldn't be overwritten by a stale value from another.
+  // - trainingState: remote wins if it has any lift state OR muscle anchors.
+  //   The engine's per-lift state is derived from history, but it's expensive
+  //   to recompute and includes cycle context (deload, recovery counters)
+  //   that aren't trivially redivable. Treating it as canonical-from-blob
+  //   when present, falling back to local for first-ever sync, is the
+  //   simplest correct behaviour.
   // - History: union by id, sorted chronologically
   const mergedMeta = {
     weights: { ...localMeta.weights, ...(remoteMeta.weights || {}) },
@@ -512,6 +522,25 @@ function mergeProfileData(local, remote) {
     userFocus: remoteMeta.userFocus ?? localMeta.userFocus ?? null,
     dayDone: { ...(localMeta.dayDone || {}), ...(remoteMeta.dayDone || {}) },
     bonusDone: { ...(localMeta.bonusDone || {}), ...(remoteMeta.bonusDone || {}) },
+    bodyweight: (() => {
+      const r = remoteMeta.bodyweight, l = localMeta.bodyweight;
+      if (!r) return l ?? null;
+      if (!l) return r;
+      // Both present — pick by timestamp. Falls back to remote if either
+      // is malformed (defensive — never lose a real value).
+      const rt = new Date(r.updatedAt || 0).getTime();
+      const lt = new Date(l.updatedAt || 0).getTime();
+      return rt >= lt ? r : l;
+    })(),
+    trainingState: (() => {
+      const r = remoteMeta.trainingState, l = localMeta.trainingState;
+      const liftCount = (s) => s?.lifts ? Object.keys(s.lifts).length : 0;
+      const anchorCount = (s) => s?.muscleAnchors ? Object.keys(s.muscleAnchors).length : 0;
+      const richness = (s) => liftCount(s) + anchorCount(s);
+      if (richness(r) > 0) return r;
+      if (richness(l) > 0) return l;
+      return r ?? l ?? null;
+    })(),
     displayName: remoteMeta.displayName || localMeta.displayName,
   };
   const mergedHistory = H.merge(localHistory, remoteHistory);
@@ -544,6 +573,17 @@ export function getLocalProfile(profile) {
       userFocus: F.get(profile),
       dayDone: P.getDayDone(profile),
       bonusDone: P.getBonusDone(profile),
+      // Bodyweight: lost on reinstall before this. Needed by the BW-
+      // progression exercises AND by the progression engine's confidence
+      // calibration. Synced as the raw stored shape ({kg, updatedAt}) so
+      // the merge can compare timestamps.
+      bodyweight: BW.getRaw(profile),
+      // TrainingState: per-lift currentWeight / e1RM / stall signal /
+      // consecutive holds, muscle anchors for cold-start, mesocycle and
+      // deload state, volume aggregates. Without this on the blob, a
+      // reinstall cold-starts the engine as if the user has never
+      // trained — even though history fully rehydrates.
+      trainingState: TS.get(profile),
     },
     history: H.get(profile),
   };
@@ -568,6 +608,13 @@ function persistToLocal(profile, { meta, history }) {
   }
   if (meta.bonusDone && Object.keys(meta.bonusDone).length > 0) {
     LS.set(`forge:${profile}:bonusDone:${weekKey()}`, meta.bonusDone);
+  }
+  if (meta.bodyweight) BW.saveRaw(profile, meta.bodyweight);
+  if (meta.trainingState && (
+    Object.keys(meta.trainingState.lifts || {}).length > 0 ||
+    Object.keys(meta.trainingState.muscleAnchors || {}).length > 0
+  )) {
+    TS.replaceState(profile, meta.trainingState);
   }
   H.save(profile, history || []);
 }
@@ -939,6 +986,22 @@ export const BW = {
   getKg: (profile) => {
     const bw = BW.get(profile);
     return bw ? bw.kg : null;
+  },
+
+  // Returns the raw stored shape ({ kg, updatedAt } | null), no derived
+  // ageMs. Used by the sync payload — blob serialises this as-is so
+  // mergeProfileData can timestamp-compare cross-device updates without
+  // smuggling a derived field that the next device would re-derive anyway.
+  getRaw: (profile) => {
+    if (!profile) return null;
+    return LS.get(BW.key(profile), null);
+  },
+
+  // Persist a raw {kg, updatedAt} object as-is — used by the sync hydration
+  // path to land a remote-merged bodyweight without bumping updatedAt.
+  saveRaw: (profile, raw) => {
+    if (!profile || !raw || typeof raw.kg !== "number") return;
+    LS.set(BW.key(profile), { kg: raw.kg, updatedAt: raw.updatedAt || new Date().toISOString() });
   },
 
   set: (profile, kg) => {


### PR DESCRIPTION
…sh-on-bonus

User reported losing two months of context after a reinstall: rotation reverted to Forge, streaks zeroed, and Performance Lab read as a dead-empty card. PR #115 closed the schedule / focus / dayDone / bonusDone gap on the meta payload, but four more stores were still local-only:

  - BW    (bodyweight)        — not in meta
  - TS    (trainingState)     — not in meta
  - PB    (programmeBlock)    — pushed only on session-finalise
  - bonusDone push timing     — pushed only on session-finalise

After a reinstall the engine would cold-start (no per-lift state, no muscle anchors, no mesocycle context) and BW-progression slots had nothing to anchor against. Rotation+bonusDone changes made between two reinstalls weren't durable until the next training session pushed.

Architecture rationale: server meta PUT is a full overwrite, so missing fields in the client payload silently drop the corresponding state. The fix is to (a) include every persisted store in the meta payload and (b) push on every mutation that changes one, rather than relying on session-finalise to act as a sync point.

storage.js
  - BW.getRaw / BW.saveRaw — raw {kg, updatedAt} shape for sync.
  - _handleOnline + getLocalProfile carry bodyweight and trainingState.
  - mergeProfileData adds rules:
      bodyweight     — latest-wins by updatedAt
      trainingState  — pick by richness (lifts + muscleAnchors), so a
                       cold-start blob never clobbers a populated local.
  - persistToLocal hydrates BW + TS into localStorage from merged meta.

ForgeApp.jsx
  - pushUserStateSnapshot now includes bodyweight + trainingState.
  - commitRotationPreview pushes after PB.save — rotation survives a pre-session reinstall.
  - handleMarkBonusDone pushes after the local tick — bonus marks survive a pre-session reinstall.
  - handleSyncUpdate reflects incoming bodyweight + trainingState into React state (BW kg, activeDeload, deloadOffer) so the UI catches up in the same tick as the other fields.

351 tests, lint, typecheck, build all clean.


Claude-Session: https://claude.ai/code/session_01Gucgxvub2JW5XT1q9dhU8f