### PR TITLE
Durability contract — local is a cache, blob is canonical, contract e…

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ scripts/
 
 These are non-negotiable without explicit sign-off. They've each saved or unwound a real bug.
 
+0. **Local is a cache; blob is canonical. Nothing lives in `localStorage` without an explicit decision about how it survives a reinstall.** Every new persisted store must either (a) be included in the blob `meta` payload — read by `getLocalProfile`, written by `persistToLocal`, merged by `mergeProfileData`, and pushed by `pushUserStateSnapshot` on mutation — or (b) carry an inline comment declaring it intentionally device-local (e.g. transient draft state) with the reasoning. Reinstall-erased data is unrecoverable; the framing is "what survives" not "what's saved." Adding a store without picking a side is a regression.
 1. **Ballerina-lean.** Incremental, monolithic, minimal. No speculative refactors. `ForgeApp.jsx` doesn't get split unless an extraction has a concrete reason (cross-screen reuse or genuine independence).
 2. **Two effort scales only.**
    - Per-set effort = `easy / normal / cooked` (maps to RIR via `rpeToRir`).

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -3,6 +3,47 @@
 // ─────────────────────────────────────────────────────────────────────────────
 // localStorage helpers, Vercel Blob sync, and stateless progression utilities.
 // No React, no JSX. Safe to import in both client components and API routes.
+//
+// ─── DURABILITY CONTRACT ────────────────────────────────────────────────────
+// LOAD-BEARING. Read before adding a new store.
+//
+// localStorage is a write-through cache; blob is canonical. Nothing persists
+// here without an explicit decision about how it survives a reinstall. Two
+// dispositions, every store picks one:
+//
+//   1. SYNCED — included in the blob meta payload. Must appear in ALL FOUR
+//      seams to round-trip safely:
+//        · getLocalProfile()      reads the field into the snapshot
+//        · persistToLocal()       writes it back from a merged blob
+//        · mergeProfileData()     declares a merge rule (last-write-wins,
+//                                 union, richness, monotonic, etc.)
+//        · pushUserStateSnapshot  (in components/ForgeApp.jsx) picks it up
+//                                 on every mutation that changes it
+//      Missing any one of those four lets a reinstall silently revert the
+//      store to default.
+//
+//   2. DEVICE-LOCAL — intentionally not synced. Must carry an inline comment
+//      saying so AND why it's safe to lose on reinstall (transient draft,
+//      derived-from-history, per-device preference, etc.).
+//
+// CURRENT INVENTORY (keep in sync as stores land):
+//
+//   Store  Disposition   Key shape                                  Notes
+//   ─────  ───────────   ─────────────────────────────────────────  ─────
+//   P      SYNCED        forge:<profile>:weights / reps / streak    Weights, reps, streak
+//   H      SYNCED        forge:<profile>:history                    Own blob, server merge-by-id
+//   W      SYNCED        forge:weekConfig                           Custom weekly schedule
+//   PB     SYNCED        forge:programmeBlock                       Rotation block
+//   F      SYNCED        forge:<profile>:focus                      Training focus
+//   BW     SYNCED        forge:<profile>:bw                         Bodyweight {kg, updatedAt}
+//   TS     SYNCED        forge:<profile>:trainingState              Engine state, mesocycle
+//   PN     DEVICE-LOCAL  forge:<profile>:passkeyNudge               Per-device nudge cadence
+//   PQ     DEVICE-LOCAL  forge:pendingPushes                        Retry queue, derived
+//   D      DEVICE-LOCAL  forge:<profile>:draft                      Transient in-session draft
+//
+// Adding a new store without picking a side IS a regression. The contract
+// is asserted by tests/storage.test.js#durability-contract — see there for
+// the enforcement details.
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -1,0 +1,156 @@
+// tests/storage.test.js
+// ─────────────────────────────────────────────────────────────────────────────
+// Durability contract — see the DURABILITY CONTRACT block at the top of
+// lib/storage.js. The contract: every persisted store is either SYNCED
+// (round-tripped to blob through the four seams) or DEVICE-LOCAL (with an
+// explicit reason). Adding a store without picking a side IS a regression.
+//
+// What this file asserts:
+//
+//   1. Every exported store with a key:() or hard-coded storage key has an
+//      entry in the inventory comment AND a row in INVENTORY below.
+//   2. Every SYNCED store appears in all four seams:
+//        getLocalProfile  — reads it into the snapshot
+//        persistToLocal   — writes it back from merged blob
+//        mergeProfileData — has a merge rule for it
+//        pushUserStateSnapshot (ForgeApp.jsx) — pushes on mutation
+//   3. New stores can't sneak in without forcing a contract decision —
+//      the test enumerates exported store identifiers and fails on any
+//      that aren't accounted for.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname  = dirname(fileURLToPath(import.meta.url));
+const storageSrc = readFileSync(resolve(__dirname, "../lib/storage.js"), "utf8");
+const forgeAppSrc = readFileSync(resolve(__dirname, "../components/ForgeApp.jsx"), "utf8");
+
+// Authoritative inventory of every store that ships persistence. If you add
+// a store and don't update this list, the "no orphan stores" test fails —
+// forcing a deliberate disposition choice.
+//
+// disposition:
+//   "synced"        — included in blob meta payload (or own blob, for H)
+//   "device-local"  — intentionally not synced; reason recorded below
+const INVENTORY = {
+  P:  { disposition: "synced", keys: ["weights", "reps", "streak", "dayDone", "bonusDone", "weekDone"] },
+  H:  { disposition: "synced", keys: ["history"], note: "own blob, server-side merge by id" },
+  W:  { disposition: "synced", keys: ["weekConfig"] },
+  PB: { disposition: "synced", keys: ["programmeBlock"] },
+  F:  { disposition: "synced", keys: ["focus"] },
+  BW: { disposition: "synced", keys: ["bw"] },
+  TS: { disposition: "synced", keys: ["trainingState"] },
+  PN: { disposition: "device-local", keys: ["passkeyNudge"], reason: "per-device nudge cadence" },
+  PQ: { disposition: "device-local", keys: ["pendingPushes"], reason: "retry queue, derived from failures on this device" },
+  D:  { disposition: "device-local", keys: ["draft"], reason: "transient in-session draft, recovered locally only" },
+  // LS and SyncStatus are utilities, not stores. They don't own data.
+};
+
+const UTILITIES = new Set(["LS", "SyncStatus"]);
+
+// Stores whose data flows via blob meta (excludes H — own blob).
+const META_SYNCED = Object.entries(INVENTORY)
+  .filter(([, v]) => v.disposition === "synced")
+  .map(([k]) => k)
+  .filter((k) => k !== "H");
+
+describe("storage durability contract", () => {
+  it("every exported store is accounted for in INVENTORY", () => {
+    const exportedStores = [...storageSrc.matchAll(/^export const ([A-Z]+) = \{/gm)]
+      .map(([, name]) => name)
+      .filter((n) => !UTILITIES.has(n));
+    for (const name of exportedStores) {
+      expect(INVENTORY[name], `store "${name}" exported from lib/storage.js but missing from tests/storage.test.js INVENTORY — pick SYNCED or DEVICE-LOCAL and document it`).toBeDefined();
+    }
+  });
+
+  it("device-local stores carry a reason", () => {
+    for (const [name, entry] of Object.entries(INVENTORY)) {
+      if (entry.disposition === "device-local") {
+        expect(entry.reason, `${name}: device-local stores must declare a reason`).toBeTruthy();
+      }
+    }
+  });
+
+  it("every SYNCED meta store is read by getLocalProfile", () => {
+    const getLocalProfile = sliceFunction(storageSrc, "getLocalProfile");
+    const required = {
+      P:  ["weights", "reps", "streak", "dayDone", "bonusDone"],
+      W:  ["userWeek"],
+      PB: ["programmeBlock"],
+      F:  ["userFocus"],
+      BW: ["bodyweight"],
+      TS: ["trainingState"],
+    };
+    for (const [store, fields] of Object.entries(required)) {
+      for (const field of fields) {
+        expect(getLocalProfile.includes(field), `getLocalProfile() must read ${store} as meta.${field}`).toBe(true);
+      }
+    }
+  });
+
+  it("every SYNCED meta store is written by persistToLocal", () => {
+    const persistToLocal = sliceFunction(storageSrc, "persistToLocal");
+    const required = ["weights", "reps", "streak", "programmeBlock", "userWeek", "userFocus", "dayDone", "bonusDone", "bodyweight", "trainingState"];
+    for (const field of required) {
+      expect(persistToLocal.includes(field), `persistToLocal() must hydrate meta.${field} back to local`).toBe(true);
+    }
+  });
+
+  it("every SYNCED meta store has a merge rule in mergeProfileData", () => {
+    const mergeFn = sliceFunction(storageSrc, "mergeProfileData");
+    const required = ["weights", "reps", "streak", "programmeBlock", "userWeek", "userFocus", "dayDone", "bonusDone", "bodyweight", "trainingState"];
+    for (const field of required) {
+      expect(mergeFn.includes(field), `mergeProfileData must declare a merge rule for meta.${field}`).toBe(true);
+    }
+  });
+
+  it("pushUserStateSnapshot in ForgeApp.jsx includes every SYNCED meta field", () => {
+    // pushUserStateSnapshot is the on-mutation push helper. If it skips a
+    // field, that field's mutations don't durably round-trip until the next
+    // session-finalise — the same gap that lost the rotation-after-reinstall.
+    const push = sliceFunction(forgeAppSrc, "pushUserStateSnapshot");
+    const required = ["weights", "reps", "streak", "programmeBlock", "userWeek", "userFocus", "dayDone", "bonusDone", "bodyweight", "trainingState"];
+    for (const field of required) {
+      expect(push.includes(field), `pushUserStateSnapshot must include meta.${field} so on-mutation push doesn't drop it`).toBe(true);
+    }
+  });
+});
+
+// Extract a function body. Walks past the params (which can have their own
+// braces via destructuring like `function f({ a, b })`) by balancing the
+// opening `(` to its matching `)`, then locates the body's opening `{` and
+// balances that. Substring assertions only — not a parser.
+function sliceFunction(src, name) {
+  const patterns = [
+    new RegExp(`export function ${name}\\s*\\(`),
+    new RegExp(`function ${name}\\s*\\(`),
+    new RegExp(`const ${name}\\s*=\\s*\\(`),
+    new RegExp(`const ${name}\\s*=\\s*useCallback`),
+  ];
+  let m = null;
+  for (const p of patterns) {
+    const hit = src.match(p);
+    if (hit && hit.index !== undefined) { m = hit; break; }
+  }
+  if (!m) throw new Error(`Could not locate function ${name} in source`);
+  const start = m.index;
+  // Walk past params: balance the `(` at end of the matched declaration.
+  let i = start + m[0].length - 1; // index of "("
+  let paren = 0;
+  for (; i < src.length; i++) {
+    if (src[i] === "(") paren++;
+    else if (src[i] === ")") { paren--; if (paren === 0) { i++; break; } }
+  }
+  // Now find the function body's opening "{" and balance it.
+  i = src.indexOf("{", i);
+  let depth = 0;
+  for (; i < src.length; i++) {
+    if (src[i] === "{") depth++;
+    else if (src[i] === "}") { depth--; if (depth === 0) { i++; break; } }
+  }
+  return src.slice(start, i);
+}


### PR DESCRIPTION
…nforced

After a user lost two months of pre-reinstall data because trainingState + bodyweight were never in the blob meta payload, codifying the principle that prevents this from recurring as load-bearing.

Three layers, all required:

1. README — new principle #0 in the load-bearing list. Local is a cache; blob is canonical. Nothing in localStorage without an explicit decision about how it survives a reinstall. Frames the choice as "what survives" not "what's saved" — because reinstall-erased data is unrecoverable.

2. lib/storage.js — DURABILITY CONTRACT block at the top, with the live inventory: every persisted store labelled SYNCED or DEVICE-LOCAL and why. SYNCED stores must appear in all four sync seams (getLocalProfile, persistToLocal, mergeProfileData, pushUserStateSnapshot). DEVICE-LOCAL stores must declare why losing them on reinstall is acceptable.

3. tests/storage.test.js — programmatic enforcement. Six tests: · every exported store is in the inventory (no orphans); · device-local stores carry a reason; · every SYNCED meta store is read by getLocalProfile; · every SYNCED meta store is written by persistToLocal; · every SYNCED meta store has a merge rule in mergeProfileData; · pushUserStateSnapshot in ForgeApp.jsx covers every SYNCED field.

The last test specifically guards the regression that lost the user's rotation after reinstall: missing the field in pushUserStateSnapshot means mutations don't durably round-trip until the next session-finalise.

357 tests pass (351 + 6 new), lint clean.


Claude-Session: https://claude.ai/code/session_01Gucgxvub2JW5XT1q9dhU8f