### PR TITLE
Save-point push on visibilitychange=hidden + pagehide

### DIFF
--- a/components/ForgeApp.jsx
+++ b/components/ForgeApp.jsx
@@ -665,8 +665,11 @@ export default function ForgeApp(){
         if (!cancelled) setHydrating(false);
       });
 
-    // Enable auto-sync on visibility change and online events
-    enableAutoSync(activeProfile, onSyncUpdate);
+    // Enable auto-sync on visibility change and online events.
+    // The third arg is the "push current snapshot" callback — fires on
+    // visibilitychange=hidden and pagehide so a backgrounding event is a
+    // durability checkpoint, not a data-loss window.
+    enableAutoSync(activeProfile, onSyncUpdate, pushUserStateSnapshot);
 
     // Check for an interrupted session — surfaces as a resume card on home
     const interrupted = D.load(activeProfile);
@@ -712,6 +715,10 @@ export default function ForgeApp(){
       cancelled = true;
       disableAutoSync();
     };
+    // pushUserStateSnapshot is itself memoised on [activeProfile] — listing
+    // it in deps would re-run this effect identically. Suppressed for the
+    // same reason the catch-up rebuild suppresses below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   },[activeProfile]);
 
   // Rest timer tick

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -26,6 +26,16 @@
 //      saying so AND why it's safe to lose on reinstall (transient draft,
 //      derived-from-history, per-device preference, etc.).
 //
+// THREE SAVE POINTS guarantee a SYNCED store reaches the blob:
+//   · on mutation         — pushUserStateSnapshot fires inside the handler
+//   · on visibilitychange — _flushSnapshotPush fires when the tab hides
+//                           (the user's "I'll close this for now" event)
+//   · on pagehide         — same callback, fires on iOS Safari's more
+//                           reliable termination signal
+// Any one of these three would be enough in a perfect world; together they
+// cover the race where a mutation push is in flight when the OS suspends
+// the tab. Don't remove a save point without thinking about what fails.
+//
 // CURRENT INVENTORY (keep in sync as stores land):
 //
 //   Store  Disposition   Key shape                                  Notes
@@ -424,25 +434,58 @@ export const SyncStatus = {
 if (typeof window !== "undefined") SyncStatus._init();
 
 // ─── Auto-sync on visibility/online ──────────────────────────────────────────
-// Retry sync when the app comes back into focus or reconnects to the network.
-// This is fire-and-forget — no blocking, no errors surfaced.
+// Two paired transitions per app cycle:
+//
+//   visible  → backgroundSync (pull merged data, hydrate React state)
+//   hidden   → flush a snapshot push (last chance to durably persist before
+//              the OS reclaims the tab / iOS pauses JS execution)
+//   online   → flush push queue + pull
+//
+// The hidden→push half is non-negotiable for durability. Without it, marks
+// made while the app is open ride only on the per-mutation push (which can
+// race, fail, or be deferred for stores that don't have a push wired into
+// their mutation site). With it, every backgrounding event is a save point
+// — the same model native apps use. iOS Safari fires pagehide more
+// reliably than visibilitychange in some scenarios; we listen to both.
 let _autoSyncProfile = null;
 let _autoSyncCallback = null;
+let _autoSyncPush = null;  // () => void from caller; pushes current snapshot
 
-export function enableAutoSync(profile, onUpdate) {
+export function enableAutoSync(profile, onUpdate, pushSnapshot) {
   _autoSyncProfile = profile;
   _autoSyncCallback = onUpdate;
+  _autoSyncPush = pushSnapshot || null;
 }
 
 export function disableAutoSync() {
   _autoSyncProfile = null;
   _autoSyncCallback = null;
+  _autoSyncPush = null;
+}
+
+// Best-effort push of the current snapshot. Used by hide / pagehide so a
+// pending mutation that hadn't yet been pushed doesn't get lost when the
+// OS suspends the tab. Falls through silently — the per-mutation pushes
+// and the pending-push queue cover retry on the next event.
+function _flushSnapshotPush() {
+  if (!_autoSyncProfile || !_autoSyncPush) return;
+  try {
+    _autoSyncPush();
+  } catch (e) {
+    console.warn("[forge:sync:hidden]", e?.message || e);
+  }
 }
 
 function _handleVisibilityChange() {
   if (document.visibilityState === "visible" && _autoSyncProfile) {
     backgroundSync(_autoSyncProfile, { onUpdate: _autoSyncCallback });
+  } else if (document.visibilityState === "hidden") {
+    _flushSnapshotPush();
   }
+}
+
+function _handlePageHide() {
+  _flushSnapshotPush();
 }
 
 function _handleOnline() {
@@ -473,6 +516,9 @@ function _handleOnline() {
 if (typeof window !== "undefined") {
   document.addEventListener("visibilitychange", _handleVisibilityChange);
   window.addEventListener("online", _handleOnline);
+  // pagehide is the reliable "tab is going away" signal on iOS Safari —
+  // visibilitychange to "hidden" misses some PWA backgrounding cases there.
+  window.addEventListener("pagehide", _handlePageHide);
 }
 
 export async function blobPull(profile) {


### PR DESCRIPTION
User reported losing dayDone / bonusDone marks across a reinstall despite "going in and out of the app a few times to force a sync." The going-in half was wired (visibilitychange → backgroundSync, pull-only); the going-out half wasn't. Every backgrounding event was a pull point but never a push point, so the per-mutation push was the ONLY path for marks to reach the blob — and any failure / race / unwired handler dropped the mark on the floor with no second chance.

Three save points now guarantee a SYNCED store reaches the blob:

  1. on mutation         — pushUserStateSnapshot inside the handler
  2. on visibilitychange — _flushSnapshotPush when the tab hides (the
                           user's "I'll close this for now" event)
  3. on pagehide         — same flush, iOS Safari's more reliable
                           termination signal in PWA install mode

Any one of the three would cover the common case in isolation. Together they survive the race where a per-mutation push is in flight when the OS suspends the tab — which is exactly the scenario that lost the user's seven days of marks.

Wiring:
  lib/storage.js
    - enableAutoSync gains a third arg: pushSnapshot callback. Storage doesn't know how to build a snapshot itself — the caller owns that.
    - _handleVisibilityChange now branches: visible → pull, hidden → push.
    - New _handlePageHide → push (pagehide listener added on mount).
    - DURABILITY CONTRACT block documents the three save points so a future change can't accidentally remove one without thinking about what fails.

  components/ForgeApp.jsx
    - enableAutoSync now receives pushUserStateSnapshot as the third arg.
    - Effect-deps suppressed with the same justification as the catch-up effect below: pushUserStateSnapshot is itself memoised on [activeProfile], so listing it would re-run identically.

357 tests, lint, typecheck, build clean.


Claude-Session: https://claude.ai/code/session_01Gucgxvub2JW5XT1q9dhU8f