### PR TITLE
View-transition polish — turbo grain, fade pop-in, frosted scroll-under

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -123,13 +123,31 @@ input, button, textarea, select { font: inherit; }
    old AND new root snapshots; cross-fading them with plus-lighter doubles
    the grain at midpoint and reads as a dim — exactly the regression that
    landed when grain went opacity 0.05 overlay → 0.12 screen and made the
-   layer dense enough to matter. The grain itself shouldn't animate — it's
-   a static decoration, identical on every screen — so both pseudo-elements
-   get animation:none. The element persists visually across the transition
-   while the root pseudos animate cleanly. */
+   layer dense enough to matter. The plus-lighter fix never knew about a
+   layer composing on top.
+
+   Within the grain's own group, the SAME doubling can happen if both
+   old + new pseudos render at full opacity simultaneously (which is what
+   `animation: none` on both gives you — that was the "turbo grain" the
+   user caught after the initial fix). The clean treatment is to suppress
+   the old pseudo entirely and pin the new at full opacity: since grain
+   is visually identical between old and new (it's a static decoration),
+   showing only the new throughout produces a layer that looks IDENTICAL
+   to its non-transition state. No turbo, no dim, no flicker. */
 ::view-transition-group(forge-grain) { animation: none; }
-::view-transition-old(forge-grain),
-::view-transition-new(forge-grain) { animation: none; }
+::view-transition-old(forge-grain)   { animation: none; opacity: 0; }
+::view-transition-new(forge-grain)   { animation: none; opacity: 1; }
+
+/* Same treatment for the top-fade overlay (status-bar continuity). Without
+   the opt-out, the fade was baked into both root snapshots; plus-lighter
+   on the root pseudos summed two dark gradient layers and brightened the
+   fade region mid-transition, then it "popped in" to its real darkness
+   when the transition ended (user-reported, screenshot captured mid-
+   transition). Same opacity-0/opacity-1 pin keeps the fade looking static
+   throughout. */
+::view-transition-group(forge-top-fade) { animation: none; }
+::view-transition-old(forge-top-fade)   { animation: none; opacity: 0; }
+::view-transition-new(forge-top-fade)   { animation: none; opacity: 1; }
 
 /* (2) Drum item magnification via view-timeline. The drum container is
    the implicit scrollport (overflow:scroll, height:5×52px), so view(y)

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -80,19 +80,44 @@ export default function RootLayout({ children }) {
             Performance Lab day-type radial glows bloom at the very top of
             the content area, painting warm tints right against the dark
             status bar — visible as a hard horizontal seam at the boundary
-            (user-reported screenshot, 2026-06-19). A 60px linear fade from
-            #131110 → transparent at the top of the viewport dissolves
-            that seam: glow still reads as "warm light from above" but
-            doesn't hit the very top edge. Also masks the grain layer from
-            the Dynamic Island adjacency zone, since the fade sits above
-            grain (zIndex 2 vs 1) and absorbs the screen-blended noise at
-            its opaque end. Pointer-events: none keeps it cosmetic. */}
+            (user-reported screenshot, 2026-06-19).
+
+            Two jobs:
+
+            1. AT SCROLL-TOP: dissolve the seam. The linear gradient is
+               solid #131110 at the very top (matching the status-bar zone
+               directly above) and tapers to transparent at the bottom of
+               the band, so the day-type glow blooms below it cleanly.
+
+            2. WHILE SCROLLING: handle content sliding into the top edge
+               iOS-natively. backdrop-filter blur(20px) + saturate(180%)
+               is the standard frosted-glass treatment Safari, Apple's
+               own apps, and most native nav bars use — content scrolling
+               UP into this band gets blurred + slightly more saturated
+               rather than just darkening to dead grey. The user asked
+               whether content "should slide along"; this is the iOS
+               idiom for that behaviour.
+
+            Named for its own view-transition group so root cross-fades
+            (Home ↔ Performance Lab) don't bake it into both snapshots
+            and brighten the fade region mid-transition — see globals.css
+            for the pinned-pseudo treatment.
+
+            Pointer-events: none keeps it strictly cosmetic. zIndex 2 sits
+            above grain (1) so the fade also masks grain noise out of the
+            Dynamic Island adjacency zone. */}
         <div aria-hidden="true" style={{
           position: "fixed",
           top: 0, left: 0, right: 0, height: 60,
-          background: "linear-gradient(to bottom, #131110 0%, rgba(19,17,16,0) 100%)",
+          // Solid at top, partially transparent in the middle (so
+          // backdrop-filter has something to act on), transparent at the
+          // bottom (so the day-type glow blooms below the band).
+          background: "linear-gradient(to bottom, #131110 0%, rgba(19,17,16,0.70) 55%, rgba(19,17,16,0) 100%)",
+          backdropFilter: "blur(20px) saturate(180%)",
+          WebkitBackdropFilter: "blur(20px) saturate(180%)",
           pointerEvents: "none",
           zIndex: 2,
+          viewTransitionName: "forge-top-fade",
         }}/>
         <Analytics />
         <SpeedInsights />


### PR DESCRIPTION
User caught the three remaining polish issues after the dim fix landed, with screenshots for each:

  1. "Turbo grain" during transitions — grain getting denser then snapping back. My initial fix on the grain pseudos used `animation: none` on BOTH old + new. That pins both at full opacity simultaneously, so two copies of the screen-blended grain composite together inside the grain's own view-transition-group: ~2× density at midpoint, reading exactly as "turbo grain". The opt-out-of-root fix removed the root-level doubling; this commit closes the same trap inside the grain's own group.

  2. "Fade pops in" — caught on a mid-transition screenshot where the status-bar adjacency band looks LIGHTER than its settled state. The fade was still in the root capture, so plus-lighter on the root pseudos was summing two dark-gradient layers (#131110 + #131110 → #262220, twice as bright) for the duration of the transition, then snapping back to true darkness when the transition ended. Same root-opt-out treatment as grain.

  3. "Should content slide along?" — the user's instinct is right: the iOS idiom for content scrolling into a top band is frosted glass (backdrop-filter blur + saturation boost), not a flat colour fade. The previous version of the fade dissolved the seam correctly at scroll-top but read as dead-grey darkening while scrolled.

Fixes
  app/globals.css
    - Grain pseudos: opacity 0 on old, opacity 1 on new (instead of animation:none on both). Since old and new are visually identical (static decoration), pinning ONLY the new to full opacity produces a layer that looks identical to its non-transition state. No turbo, no dim, no flicker.
    - Top-fade pseudos: same opacity-0/opacity-1 treatment, paired with view-transition-name: forge-top-fade in layout.jsx (below) to pull the fade out of root capture entirely.

  app/layout.jsx
    - Fade element gains viewTransitionName: "forge-top-fade" so it gets its own capture group (fixes the pop-in).
    - Background gradient adjusted: solid #131110 at top → rgba(_,0.70) at 55% → transparent at bottom. The partial-alpha middle band gives backdrop-filter something to act on (with full alpha there'd be no visible blur effect since the gradient would cover the backdrop).
    - backdrop-filter: blur(20px) saturate(180%) + Webkit prefix. Standard iOS frosted-glass treatment — content scrolling UP into the band gets blurred + saturated, matching native nav bars and Safari's own URL bar. This is the "slide along" the user was asking about.
    - Long comment block documents the two jobs (seam dissolve at scroll- top, frosted blur while scrolling) plus the view-transition opt-out rationale so a future reader doesn't undo any of the three.

Behaviour now:
  - Home → Performance Lab cross-fade has neither dim nor turbo grain nor fade flicker. Grain and fade are visually static across the transition; only the actual page content cross-fades.
  - At scroll-top, status-bar seam still dissolves cleanly (no change from the previous commit's positive behaviour).
  - While scrolled, content sliding into the top band is iOS-native frosted glass instead of flat darkening.

407 tests, lint, typecheck, build clean.


Claude-Session: https://claude.ai/code/session_01Gucgxvub2JW5XT1q9dhU8f