### PR TITLE
Top fade — drop opacity at the seam, soften the snapshot mismatch

### DIFF
--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -109,12 +109,25 @@ export default function RootLayout({ children }) {
         <div aria-hidden="true" style={{
           position: "fixed",
           top: 0, left: 0, right: 0, height: 60,
-          // Solid at top, partially transparent in the middle (so
-          // backdrop-filter has something to act on), transparent at the
-          // bottom (so the day-type glow blooms below the band).
-          background: "linear-gradient(to bottom, #131110 0%, rgba(19,17,16,0.70) 55%, rgba(19,17,16,0) 100%)",
-          backdropFilter: "blur(20px) saturate(180%)",
-          WebkitBackdropFilter: "blur(20px) saturate(180%)",
+          // The top of the gradient is intentionally NOT opaque #131110 —
+          // matching the status bar exactly created a perceptually
+          // isolated dark band ("transparency too low, status bar still a
+          // black hole"). Starting at 55% alpha lets the underlying page
+          // (with day-type glow above the fold) bleed through, so the
+          // fade reads as a single continuous surface with the content
+          // below rather than a second distinct band stacked on it. Mid
+          // band stays partially opaque to give backdrop-filter material
+          // to act on; bottom is transparent so the glow blooms below.
+          background: "linear-gradient(to bottom, rgba(19,17,16,0.55) 0%, rgba(19,17,16,0.25) 55%, rgba(19,17,16,0) 100%)",
+          // Softened blur + saturate. Safari has to bake backdrop-filter
+          // into view-transition snapshots, and the snapshot's backdrop
+          // doesn't always match the live element's backdrop on resume
+          // — visible as a small "flicker" the user caught on Performance
+          // Lab arrival. Less aggressive values (blur 14 vs 20, saturate
+          // 160 vs 180) keep the iOS frosted feel while making the
+          // snapshot↔live handoff less perceptible.
+          backdropFilter: "blur(14px) saturate(160%)",
+          WebkitBackdropFilter: "blur(14px) saturate(160%)",
           pointerEvents: "none",
           zIndex: 2,
           viewTransitionName: "forge-top-fade",


### PR DESCRIPTION
User feedback on the previous frosted-glass commit, with screenshot: "Transparency works but it seems a little too low, with the status bar still being mostly a black hole." And: "small flicker now for Performance Lab — much better but still just seems a bit janky."

Two tweaks, same element.

  background gradient
    Was:  #131110 0% → rgba(_,0.70) 55% → transparent 100%
    Now:  rgba(_,0.55) 0% → rgba(_,0.25) 55% → transparent 100%

    Matching the manifest's background_color exactly at the top of the
    fade DID match the status-bar zone perfectly — but it made the fade
    band itself read as a second distinct dark region stacked between
    the status bar and the glow-lit content, three zones where one
    continuous surface is wanted. Starting at 55% alpha (with the
    backdrop-filter still in play) lets the underlying page bleed
    through, so the surface visually flows from status bar through fade
    into glow rather than stepping between three brightness levels.

  backdrop-filter
    Was:  blur(20px) saturate(180%)
    Now:  blur(14px) saturate(160%)

    The "small flicker" is Safari's backdrop-filter / view-transition
    snapshot quirk: the filter has to be baked into the captured
    snapshot, but the snapshot's backdrop isn't the live one. When the
    live element resumes after the transition ends, the blurred backdrop
    re-renders against the actual current scroll position — visible as a
    momentary mismatch. Softer values keep the iOS frosted character but
    make the snapshot↔live handoff less perceptible. The flicker is
    inherent to backdrop-filter + view-transitions on iOS Safari today;
    if it remains intrusive after this lands the next step is to drop
    backdrop-filter from the view-transition group and only apply it
    on the live element via the @container or a media-query trick.

Lint, typecheck, build clean. No test changes (visual-only commit).


Claude-Session: https://claude.ai/code/session_01Gucgxvub2JW5XT1q9dhU8f