### PR TITLE
iOS PWA — spec-correct status bar handling on iOS 26.2+

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,11 +1,9 @@
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 html, body {
-  /* 100vh, not 100%. 100% calculates relative to the containing block which
-     doesn't always account for the full viewport on iOS PWAs (the bug that
-     creates the bottom chin gap if anyone re-adds the black-translucent
-     status bar later). 100vh = actual viewport height — robust to that
-     class of layout pitfall. iOS Safari's dvh would be ideal long-term but
-     vh is the broadest-supported "actual viewport" unit. */
+  /* 100vh, not 100%. 100% breaks viewport-fit: cover on iOS PWAs (Safari
+     silently falls back to default layout); 100dvh reports wrong values
+     on PWA cold start until the device rotates. 100vh works correctly
+     from launch on iOS 26.2+, the only target our baseline supports. */
   height: 100vh;
   background: #131110;
   overflow-x: hidden;
@@ -14,8 +12,58 @@ html, body {
      it's gone. Sheet scrims keep their own `overscroll-behavior: contain`
      so scrolling inside a sheet doesn't bleed into the page behind. */
 }
-body { -webkit-tap-highlight-color: transparent; font-family: var(--font-dm-sans), sans-serif; }
+body {
+  -webkit-tap-highlight-color: transparent;
+  font-family: var(--font-dm-sans), sans-serif;
+  /* Reserve the system status-bar zone at the top of body content. With
+     viewport-fit: cover + black-translucent, content extends behind the
+     status bar by default — without this padding, the first row of each
+     screen sits under the system icons at scroll-top, which iOS-native
+     apps don't do. Pushing content down by env(safe-area-inset-top) lets
+     it sit naturally below the status bar at rest, then scroll behind it
+     as the user scrolls (visible through the body::before blur below). */
+  padding-top: env(safe-area-inset-top);
+}
 input, button, textarea, select { font: inherit; }
+
+/* ─── Blurry status-bar zone ────────────────────────────────────────────────
+   Per the documented iOS PWA recipe (Sept 2025, danielpietzsch.com): a
+   body::before pseudo-element pinned to env(safe-area-inset-top) height,
+   blurring whatever content scrolls behind the system status bar. The
+   pseudo-element exists ONLY in the safe-area zone — it cannot extend
+   into the content area, so it can never mask or darken content that's
+   scrolled below it. That was the structural defect in every prior
+   fixed-pixel-height fade attempt.
+
+   Gated by @supports so older / non-supporting browsers gracefully render
+   the default (system-rendered) status bar instead of the broken absence.
+
+   The mask-image fades the blur out at the bottom edge so there's no hard
+   line where the blurred status-bar zone meets the unblurred content
+   below — particularly noticeable on the home / Performance Lab screens
+   where day-type radial glows sit just below the safe area. */
+@supports (height: env(safe-area-inset-top)) {
+  body::before {
+    content: "";
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: env(safe-area-inset-top);
+    backdrop-filter: saturate(180%) blur(20px);
+    -webkit-backdrop-filter: saturate(180%) blur(20px);
+    pointer-events: none;
+    /* zIndex high enough to sit above any in-page chrome but below modal
+       scrims (zIndex 300+) so sheet animations don't render UNDER the
+       status bar blur. */
+    z-index: 50;
+    /* Soften the bottom edge so the blur transitions cleanly into the
+       content surface below. Full opacity for the top ~60%, fading to
+       transparent at the bottom edge. */
+    -webkit-mask-image: linear-gradient(to bottom, #000 60%, transparent);
+    mask-image: linear-gradient(to bottom, #000 60%, transparent);
+  }
+}
 
 /* ─── Keyframe library ─────────────────────────────────────────────────────
    Animations consolidated here from inline <style> tags in ForgeApp.jsx.
@@ -138,16 +186,9 @@ input, button, textarea, select { font: inherit; }
 ::view-transition-old(forge-grain)   { animation: none; opacity: 0; }
 ::view-transition-new(forge-grain)   { animation: none; opacity: 1; }
 
-/* Same treatment for the top-fade overlay (status-bar continuity). Without
-   the opt-out, the fade was baked into both root snapshots; plus-lighter
-   on the root pseudos summed two dark gradient layers and brightened the
-   fade region mid-transition, then it "popped in" to its real darkness
-   when the transition ended (user-reported, screenshot captured mid-
-   transition). Same opacity-0/opacity-1 pin keeps the fade looking static
-   throughout. */
-::view-transition-group(forge-top-fade) { animation: none; }
-::view-transition-old(forge-top-fade)   { animation: none; opacity: 0; }
-::view-transition-new(forge-top-fade)   { animation: none; opacity: 1; }
+/* No forge-top-fade rules — the fixed fade overlay it accompanied has
+   been replaced by the body::before status-bar blur recipe at the top
+   of this file. */
 
 /* (2) Drum item magnification via view-timeline. The drum container is
    the implicit scrollport (overflow:scroll, height:5×52px), so view(y)

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -29,15 +29,15 @@ export const metadata = {
   manifest: "/manifest.json",
   appleWebApp: {
     capable: true,
-    // No statusBarStyle. The legacy "black-translucent" value has a
-    // well-documented iOS WebKit bug: it shifts the viewport upward by
-    // ~59px behind the status bar without growing the viewport, leaving
-    // a chin gap at the bottom AND making fixed overlays (e.g. our grain
-    // layer) bleed into the Dynamic Island area with mismatched contrast.
-    // Without it, iOS reserves the status bar zone, fills it with the
-    // manifest's background_color (#131110 — matches the page), and lays
-    // content cleanly underneath. See:
+    // black-translucent is the spec-correct choice for an edge-to-edge
+    // iOS PWA on iOS 26.2+. The iOS 26.1 regression (negative viewport
+    // offset producing a bottom chin gap) was fixed in iOS 26.2 beta 3;
+    // our baseline is current iOS. Paired with viewport-fit: cover below,
+    // env(safe-area-inset-*) resolves to real values and we can layout
+    // around the system status bar / Dynamic Island properly. See
     // https://gist.github.com/fozzedout/5e77925381991a9570151550992baf14
+    // and https://danielpietzsch.com/articles/how-to-create-a-blurry-status-bar-for-pwas-on-ios
+    statusBarStyle: "black-translucent",
     title: "Forge",
   },
   icons: {
@@ -55,6 +55,11 @@ export const viewport = {
   initialScale: 1,
   maximumScale: 1,
   userScalable: false,
+  // viewport-fit: cover is MANDATORY for env(safe-area-inset-*) to return
+  // non-zero values on iOS. Without it, every safe-area-inset query
+  // resolves to 0px and Safari letterboxes landscape with black bars.
+  // This unblocks the body::before status-bar blur recipe in globals.css.
+  viewportFit: "cover",
 };
 
 export default function RootLayout({ children }) {
@@ -62,8 +67,8 @@ export default function RootLayout({ children }) {
     <html lang="en" className={`${fraunces.variable} ${dmSans.variable}`}>
       <head>
         <meta name="apple-mobile-web-app-capable" content="yes" />
-        {/* Deliberately NO apple-mobile-web-app-status-bar-style: see the
-            metadata.appleWebApp block above for the WebKit-bug rationale. */}
+        <meta name="mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
       </head>
       <body>
@@ -75,63 +80,13 @@ export default function RootLayout({ children }) {
             it composites on top via mix-blend overlay; pointer-events none
             and zIndex 1 keep it strictly cosmetic. */}
         <GrainOverlay />
-        {/* Status-bar continuity fade. The iOS status-bar zone is filled
-            by the manifest's background_color (#131110), but the home /
-            Performance Lab day-type radial glows bloom at the very top of
-            the content area, painting warm tints right against the dark
-            status bar — visible as a hard horizontal seam at the boundary
-            (user-reported screenshot, 2026-06-19).
-
-            Two jobs:
-
-            1. AT SCROLL-TOP: dissolve the seam. The linear gradient is
-               solid #131110 at the very top (matching the status-bar zone
-               directly above) and tapers to transparent at the bottom of
-               the band, so the day-type glow blooms below it cleanly.
-
-            2. WHILE SCROLLING: handle content sliding into the top edge
-               iOS-natively. backdrop-filter blur(20px) + saturate(180%)
-               is the standard frosted-glass treatment Safari, Apple's
-               own apps, and most native nav bars use — content scrolling
-               UP into this band gets blurred + slightly more saturated
-               rather than just darkening to dead grey. The user asked
-               whether content "should slide along"; this is the iOS
-               idiom for that behaviour.
-
-            Named for its own view-transition group so root cross-fades
-            (Home ↔ Performance Lab) don't bake it into both snapshots
-            and brighten the fade region mid-transition — see globals.css
-            for the pinned-pseudo treatment.
-
-            Pointer-events: none keeps it strictly cosmetic. zIndex 2 sits
-            above grain (1) so the fade also masks grain noise out of the
-            Dynamic Island adjacency zone. */}
-        <div aria-hidden="true" style={{
-          position: "fixed",
-          top: 0, left: 0, right: 0, height: 60,
-          // The top of the gradient is intentionally NOT opaque #131110 —
-          // matching the status bar exactly created a perceptually
-          // isolated dark band ("transparency too low, status bar still a
-          // black hole"). Starting at 55% alpha lets the underlying page
-          // (with day-type glow above the fold) bleed through, so the
-          // fade reads as a single continuous surface with the content
-          // below rather than a second distinct band stacked on it. Mid
-          // band stays partially opaque to give backdrop-filter material
-          // to act on; bottom is transparent so the glow blooms below.
-          background: "linear-gradient(to bottom, rgba(19,17,16,0.55) 0%, rgba(19,17,16,0.25) 55%, rgba(19,17,16,0) 100%)",
-          // Softened blur + saturate. Safari has to bake backdrop-filter
-          // into view-transition snapshots, and the snapshot's backdrop
-          // doesn't always match the live element's backdrop on resume
-          // — visible as a small "flicker" the user caught on Performance
-          // Lab arrival. Less aggressive values (blur 14 vs 20, saturate
-          // 160 vs 180) keep the iOS frosted feel while making the
-          // snapshot↔live handoff less perceptible.
-          backdropFilter: "blur(14px) saturate(160%)",
-          WebkitBackdropFilter: "blur(14px) saturate(160%)",
-          pointerEvents: "none",
-          zIndex: 2,
-          viewTransitionName: "forge-top-fade",
-        }}/>
+        {/* Status-bar handling: NO fixed overlay element. The blur is
+            applied via body::before in globals.css, with its height
+            pinned to env(safe-area-inset-top) so it occupies ONLY the
+            system status-bar zone — it can never mask content scrolling
+            below it. This is the documented iOS PWA recipe; the prior
+            fixed-pixel fade was a workaround for missing viewport-fit
+            and is now removed. */}
         <Analytics />
         <SpeedInsights />
       </body>


### PR DESCRIPTION
Replaces the fixed-pixel-height fade overlay with the documented iOS PWA recipe. The prior approach was a workaround for missing viewport-fit: cover (without which env(safe-area-inset-*) resolves to 0px and Safari letterboxes landscape with black bars); the workaround ended up as a 60px fixed overlay that masked content scrolling under it — the "transparency cuts into content" issue the user reported with screenshots.

Targeting iOS 26.2+ as the baseline. Earlier 26.x carried a viewport-shift regression with black-translucent that was fixed in 26.2 beta 3 per the WebKit release notes; we're current and don't support running on broken Safari builds.

Sources for the recipe:
  - https://gist.github.com/fozzedout/5e77925381991a9570151550992baf14
  - https://danielpietzsch.com/articles/how-to-create-a-blurry-status-bar-for-pwas-on-ios
  - https://webkit.org/blog/17640/webkit-features-for-safari-26-2/

app/layout.jsx
  metadata.appleWebApp.statusBarStyle = "black-translucent" restored.
  viewport export gains viewportFit: "cover". Inline meta tags for
  apple-mobile-web-app-capable, apple-mobile-web-app-status-bar-style,
  and the cross-platform mobile-web-app-capable now match. The fixed
  fade <div> overlay is REMOVED — the structural defect was a
  fixed-pixel mask at viewport top:0 that inevitably darkens any
  content that scrolls underneath. No more workaround.

app/globals.css
  body gains padding-top: env(safe-area-inset-top) so each screen's
  first row sits below the system status bar at rest; content scrolls
  behind the status bar from there.

  New body::before pseudo-element under @supports (so older / non-
  supporting browsers gracefully fall back to a system-rendered status
  bar rather than a broken absence). Pinned to height:
  env(safe-area-inset-top) — meaning the pseudo-element exists ONLY in
  the system status-bar zone. It CANNOT extend into the content area,
  so it can never mask content scrolling below it. backdrop-filter:
  saturate(180%) blur(20px) renders the iOS-native frosted status bar
  the user was originally asking about. mask-image fades the bottom
  edge so the blur dissolves cleanly into the content surface below.

  100vh height comment updated to reflect the actual rationale (100%
  breaks viewport-fit; 100dvh reports wrong on PWA cold start) and
  drops the now-irrelevant "if anyone re-adds black-translucent" caveat
  since black-translucent is now the intended value.

  forge-top-fade view-transition rules removed (the element they
  governed is gone). Grain view-transition-name treatment retained —
  it's still needed for the mix-blend-mode + root-snapshot interaction
  that's a separate concern from the status bar work.

407 tests, lint, typecheck, build clean. Branch is current on origin/main (the prior 7c0dd60 backdrop-filter-drop commit was a narrower fix that this supersedes; reset before this commit so the branch is a clean single-commit delta on main).


Claude-Session: https://claude.ai/code/session_01Gucgxvub2JW5XT1q9dhU8f