### PR TITLE
View-transition dim — diagnostic page at /diag-vt

### DIFF
--- a/app/diag-vt/page.jsx
+++ b/app/diag-vt/page.jsx
@@ -1,0 +1,145 @@
+"use client";
+
+// app/diag-vt/page.jsx
+// ─────────────────────────────────────────────────────────────────────────────
+// View-transition cross-fade diagnostic. Isolates the dim that's persisted
+// across five attempted fixes on Home → Performance Lab navigation. The
+// strategy: minimum-viable two-screen swap using the EXACT same wrapper
+// pattern as components/ForgeApp.jsx's setScreen (document.startViewTransition
+// + flushSync), with the grain layer and body::before status-bar blur
+// suppressed via a body class so we can attribute the dim to either:
+//
+//   A. baseline root cross-fade behaviour (mix-blend-mode: plus-lighter
+//      on ::view-transition-old/new(root) isn't doing what we think)
+//   B. one of the opted-out elements still contributing to the snapshot
+//      despite the view-transition-name treatment
+//   C. something specific to the Home / Performance Lab page tree
+//
+// What to do here:
+//
+//   1. Open /diag-vt in the deployed PWA (or in Safari directly).
+//   2. Tap "Swap screens" repeatedly. Watch for the dim.
+//   3. Use the URL flags below to toggle layers, narrowing the cause:
+//
+//        /diag-vt              clean baseline (grain + status-bar blur off)
+//        /diag-vt?grain        enable grain layer for this route
+//        /diag-vt?status       enable status-bar body::before for this route
+//        /diag-vt?nopl         disable mix-blend-mode: plus-lighter on root
+//                              (predicts the original cross-fade dim)
+//
+// If dim shows at /diag-vt with nothing enabled → plus-lighter isn't
+// doing its job on iOS 26.2+/27 beta and we need a different mechanism
+// (likely opacity-pinned named root pseudos like we do for grain). That's
+// the highest-priority hypothesis.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { useCallback, useEffect, useState } from "react";
+import { flushSync } from "react-dom";
+
+const A_BG = "#221A14"; // warm-dark
+const B_BG = "#141A22"; // cool-dark — visibly different so a "dim" reads clearly
+
+export default function DiagVT() {
+  const [screen, setScreenRaw] = useState("A");
+  const [swaps, setSwaps] = useState(0);
+  const [flags, setFlags] = useState({ grain: false, status: false, nopl: false });
+
+  // Read URL flags on mount (and on hashchange so flicking flags is cheap).
+  useEffect(() => {
+    const read = () => {
+      const p = new URLSearchParams(window.location.search);
+      setFlags({
+        grain:  p.has("grain"),
+        status: p.has("status"),
+        nopl:   p.has("nopl"),
+      });
+    };
+    read();
+    window.addEventListener("popstate", read);
+    return () => window.removeEventListener("popstate", read);
+  }, []);
+
+  // Toggle body classes so globals.css can suppress / restore the grain
+  // overlay and the status-bar body::before for this route. The classes
+  // are added in this component's effect, never globally — leaves the rest
+  // of the app untouched.
+  useEffect(() => {
+    const body = document.body;
+    body.classList.add("forge-diag");
+    if (!flags.grain)  body.classList.add("forge-diag-no-grain");
+    if (!flags.status) body.classList.add("forge-diag-no-statusbar");
+    if (flags.nopl)    body.classList.add("forge-diag-no-pluslighter");
+    return () => {
+      body.classList.remove(
+        "forge-diag",
+        "forge-diag-no-grain",
+        "forge-diag-no-statusbar",
+        "forge-diag-no-pluslighter",
+      );
+    };
+  }, [flags.grain, flags.status, flags.nopl]);
+
+  const setScreen = useCallback((next) => {
+    setSwaps((n) => n + 1);
+    if (typeof document === "undefined" || !document.startViewTransition) {
+      setScreenRaw(next);
+      return;
+    }
+    document.startViewTransition(() => flushSync(() => setScreenRaw(next)));
+  }, []);
+
+  const swap = useCallback(() => setScreen(screen === "A" ? "B" : "A"), [screen, setScreen]);
+
+  const bg = screen === "A" ? A_BG : B_BG;
+  const label = screen === "A" ? "Screen A" : "Screen B";
+
+  return (
+    <div style={{
+      minHeight: "100vh",
+      background: bg,
+      color: "#EDEBE7",
+      padding: "calc(env(safe-area-inset-top) + 32px) 24px 32px",
+      display: "flex",
+      flexDirection: "column",
+      gap: 24,
+      transition: "none",  // no CSS transition — only the view-transition cross-fade
+      fontFamily: "system-ui, -apple-system, sans-serif",
+    }}>
+      <div style={{ fontSize: 12, opacity: 0.7, letterSpacing: "0.12em", textTransform: "uppercase" }}>
+        View-transition diagnostic
+      </div>
+
+      <div style={{ fontSize: 48, fontWeight: 300, lineHeight: 1.1 }}>{label}</div>
+
+      <div style={{ fontSize: 14, opacity: 0.8, lineHeight: 1.5 }}>
+        Tap below. The screen-bg cross-fades from warm to cool. With <code>plus-lighter</code>
+        working, the midpoint should stay perceptually as bright as either end-state.
+        If you see a darker dip at midpoint, plus-lighter isn&apos;t doing its job here.
+      </div>
+
+      <button onClick={swap} style={{
+        padding: "16px 24px",
+        background: "rgba(255,255,255,0.08)",
+        border: "1px solid rgba(255,255,255,0.18)",
+        borderRadius: 12,
+        color: "#EDEBE7",
+        fontSize: 16,
+        fontWeight: 500,
+        cursor: "pointer",
+        WebkitTapHighlightColor: "transparent",
+      }}>
+        Swap screens ({swaps})
+      </button>
+
+      <div style={{ fontSize: 12, lineHeight: 1.7, opacity: 0.7, marginTop: "auto" }}>
+        <div style={{ fontWeight: 600, marginBottom: 4 }}>Active flags</div>
+        <div>grain: <strong>{flags.grain ? "on" : "OFF"}</strong></div>
+        <div>status-bar blur: <strong>{flags.status ? "on" : "OFF"}</strong></div>
+        <div>plus-lighter: <strong>{flags.nopl ? "OFF" : "on"}</strong></div>
+        <div style={{ marginTop: 12, opacity: 0.8 }}>
+          Toggle via URL: <code>?grain</code> <code>?status</code> <code>?nopl</code>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -79,6 +79,32 @@ input, button, textarea, select { font: inherit; }
 ::view-transition-old(forge-status-bar)   { animation: none; opacity: 0; }
 ::view-transition-new(forge-status-bar)   { animation: none; opacity: 1; }
 
+/* ─── /diag-vt diagnostic overrides ─────────────────────────────────────────
+   Body classes toggled by app/diag-vt/page.jsx so the diag route can isolate
+   layers contributing to the persistent Performance Lab cross-fade dim.
+   These only fire when the diag page is active; they have no effect on the
+   rest of the app. See the page-level comment for the test methodology. */
+
+/* Hide the grain overlay entirely when ?grain is NOT set. */
+body.forge-diag-no-grain > div[aria-hidden="true"] {
+  display: none !important;
+}
+
+/* Suppress body::before status-bar blur when ?status is NOT set. */
+body.forge-diag-no-statusbar::before {
+  display: none !important;
+}
+
+/* Suppress mix-blend-mode: plus-lighter on root pseudos when ?nopl IS set.
+   Reverting to the default cross-fade reproduces the original midpoint dim
+   we were trying to fix in the first place — useful as a negative control:
+   if /diag-vt?nopl visibly dims and bare /diag-vt does NOT, plus-lighter
+   IS working and the persistent Lab dim is sourced from app content. */
+body.forge-diag-no-pluslighter ::view-transition-old(root),
+body.forge-diag-no-pluslighter ::view-transition-new(root) {
+  mix-blend-mode: normal;
+}
+
 /* ─── Keyframe library ─────────────────────────────────────────────────────
    Animations consolidated here from inline <style> tags in ForgeApp.jsx.
    Inline injection works (Chrome/Safari handle duplicates gracefully) but


### PR DESCRIPTION
Five attempts to fix the Home → Performance Lab cross-fade dim haven't landed. Building a minimum-viable reproduction so the next attempt is grounded in observed behaviour from a controlled environment, not another guess applied to the production tree.

Methodology

  /diag-vt renders two solid-colour "screens" (warm-dark + cool-dark) and
  swaps between them using the EXACT same wrapper the rest of the app
  uses for navigation: document.startViewTransition + flushSync. No
  glow, no animation orchestration, no per-screen layout differences.
  Just two backgrounds and the root cross-fade.

  Layers that contribute to the dim get toggled via URL flags:

    /diag-vt              clean baseline (grain off, status-bar blur off)
    /diag-vt?grain        enable grain layer for this route
    /diag-vt?status       enable body::before status-bar blur for this route
    /diag-vt?nopl         disable mix-blend-mode: plus-lighter on root
                          (negative control — predicts the original dim)

  The toggles work via body classes that the page component sets on
  mount and clears on unmount. globals.css gets four matching rules
  scoped to those classes — no effect on the rest of the app.

Interpretation matrix

  bare /diag-vt dims        → plus-lighter isn't taking effect on iOS
                              26.2+/27 beta for our exact stack. Likely
                              fix: pin root pseudos with opacity 0/1
                              (like grain + status-bar), not rely on
                              blend-mode compensation.
  ?nopl dims, bare doesn't  → plus-lighter IS working in isolation.
                              The persistent Lab dim is contributed by
                              app content the named opt-outs don't cover.
                              Add ?grain and ?status one at a time.
  bare doesn't dim, ?grain  → grain view-transition-name treatment isn't
   dims                       fully isolating it. Probably the snapshot
                              still captures something.
  bare doesn't dim, ?status → body::before treatment isn't fully working.
   dims                       Same diagnosis class.

Expected to deploy alongside the rest of the branch. Run by opening /diag-vt in the PWA, tapping "Swap screens" a few times, and observing.

407 tests, lint, typecheck, build clean.


Claude-Session: https://claude.ai/code/session_01Gucgxvub2JW5XT1q9dhU8f