### PR TITLE
Status-bar padding + the actual data bug behind 'missed workout flow …

### DIFF
--- a/components/ForgeApp.jsx
+++ b/components/ForgeApp.jsx
@@ -1354,13 +1354,22 @@ export default function ForgeApp(){
     // even if the user retroactively edits the schedule later. For the
     // non-strength tick path, completedType === scheduledType (the user just
     // confirmed they did the scheduled thing).
-    const effective = W.getEffectiveOn(dateStr);
+    //
+    // CRITICAL fallback: W.getEffectiveOn returns null when no schedule edit
+    // log exists (i.e., the user has been using the default schedule the
+    // whole time — the most common state). Without this fallback, scheduled
+    // and completed types both become null, and Days.manualTickDates filters
+    // out entries with null completedType — so the retro picker keeps
+    // surfacing the same day as "missed" no matter how many times the user
+    // taps Mark ✓. (User reported: "missed workout flow keeps bringing up
+    // the same cardio days from last week." This was the cause.)
     const dowMon = (() => {
       const [y, m, d] = dateStr.split("-").map(Number);
       const js = new Date(y, m - 1, d).getDay();
       return js === 0 ? 6 : js - 1;
     })();
-    const scheduledType = effective && effective[dowMon] ? effective[dowMon].type : null;
+    const effective = W.getEffectiveOn(dateStr) || WEEK;
+    const scheduledType = effective[dowMon]?.type || null;
     Days.set(activeProfile, dateStr, {
       scheduledType,
       completedType: scheduledType,
@@ -3190,7 +3199,7 @@ function HomeScreen({rhythm,profileName,userWeek,strengthDaySessions,onEditWeek,
 
       {/* Header */}
       <Fade d={0}>
-        <div style={{padding:"52px 24px 0",display:"flex",justifyContent:"space-between",alignItems:"flex-start"}}>
+        <div style={{padding:"max(72px, calc(env(safe-area-inset-top, 0px) + 24px)) 24px 0",display:"flex",justifyContent:"space-between",alignItems:"flex-start"}}>
           <div>
             <div style={{fontFamily:T.serif,fontSize:13,fontWeight:300,color:T.text2,fontStyle:"italic"}}>
               {new Date().toLocaleDateString("en-GB",{weekday:"long"})}

--- a/components/PerformanceLab.jsx
+++ b/components/PerformanceLab.jsx
@@ -45,7 +45,7 @@ export default function PerformanceLab({ history, onBack }) {
           primary glow — see components/ForgeApp.jsx for full rationale. */}
       <div style={{position:"absolute", top:0, left:"50%", transform:"translateX(-50%)", width:600, height:500, background:`radial-gradient(ellipse, rgba(196,168,130,0.10) 0%, transparent 65%)`, pointerEvents:"none"}}/>
 
-      <div style={{padding:"52px 24px 0", display:"flex", alignItems:"center", justifyContent:"space-between"}}>
+      <div style={{padding:"max(72px, calc(env(safe-area-inset-top, 0px) + 24px)) 24px 0", display:"flex", alignItems:"center", justifyContent:"space-between"}}>
         <button onClick={onBack} style={{background:"none", border:"none", padding:0, cursor:"pointer", fontSize:12, color:T.text3, fontFamily:T.sans}}>
           ← Home
         </button>

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -3,6 +3,8 @@
 // ─────────────────────────────────────────────────────────────────────────────
 // localStorage helpers, Vercel Blob sync, and stateless progression utilities.
 // No React, no JSX. Safe to import in both client components and API routes.
+
+import { WEEK as DEFAULT_WEEK } from "./programme.js";
 //
 // ─── DURABILITY CONTRACT ────────────────────────────────────────────────────
 // LOAD-BEARING. Read before adding a new store.
@@ -660,9 +662,19 @@ export const Days = {
       // date — for legacy users this is still the same single-config, so
       // it'll be accurate. New users with retroactive schedule edits get
       // truthful interpretation.
-      const eff = W.getEffectiveOn(date);
+      //
+      // CRITICAL fallback to DEFAULT_WEEK: W.getEffectiveOn returns null
+      // when no schedule edit log exists (the most common state). Without
+      // the fallback, scheduledType and completedType both become null,
+      // and Days.manualTickDates filters out the entry — projecting every
+      // legacy dayDone tick as INVISIBLE in the retro picker, which then
+      // surfaces the same dates as "missed" forever. This was the second
+      // half of the "retro keeps showing same cardio days from last week"
+      // bug the user reported. Fixed at both sites (here, and in
+      // handleMarkDayDone in components/ForgeApp.jsx).
+      const eff = W.getEffectiveOn(date) || DEFAULT_WEEK;
       const dow = _dowOfDate(date);
-      const scheduledType = eff && eff[dow] ? eff[dow].type : null;
+      const scheduledType = eff[dow]?.type || null;
       next[date] = {
         date,
         scheduledType,

--- a/tests/storage-days.test.js
+++ b/tests/storage-days.test.js
@@ -232,13 +232,22 @@ describe("Days — lazy projection from legacy stores", () => {
     expect(got.marks?.custom).toBe(1);
   });
 
-  it("projection without a custom schedule falls back to scheduledType=null", () => {
+  it("projection without a custom schedule falls back to the default WEEK type", () => {
+    // 2026-06-16 is a Tuesday. The default WEEK has Tuesday as zone2.
+    // Critical: scheduledType must NOT be null here — if it were, the
+    // matching completedType would also be null, and Days.manualTickDates
+    // would filter the entry out as having no completion. The retro picker
+    // would then keep showing the same date as "missed" forever. Regression
+    // guard for the bug reported on 2026-06-21.
     window.localStorage.setItem(
       "forge:alice:dayDone",
       JSON.stringify({ "2026-06-16": true }),
     );
-    // No W.save() — no effective schedule.
+    // No W.save() — no schedule edit log; fallback to DEFAULT_WEEK kicks in.
     const all = Days.getAll("alice");
-    expect(all["2026-06-16"].scheduledType).toBe(null);
+    expect(all["2026-06-16"].scheduledType).toBe("zone2");
+    expect(all["2026-06-16"].completedType).toBe("zone2");
+    // And the date appears in manualTickDates (the retro picker's read).
+    expect(Days.manualTickDates("alice")["2026-06-16"]).toBe(true);
   });
 });


### PR DESCRIPTION
…keeps repeating'

User reported three problems from device screenshots:

  1. PWA: "Saturday" headline rolls into the system status bar zone (visible in screenshot 22:28 — top of content sits underneath the Dynamic Island).
  2. Sync looks broken between PWA and Safari (PWA shows 6/12 streak + checkmarks; Safari shows 0/12 + nothing).
  3. Retro picker keeps surfacing the same cardio days from last week no matter how many times the user marks them done.

Status bar (the cosmetic one — quick fix)

  The 52px top padding I reverted to in a2e4901 was too tight for
  Dynamic Island devices (system zone reserves ~59px before Apple's
  recommended editorial spacing kicks in). At 52px, "Saturday" sat at
  viewport y=52 — still under the system zone.

  Both header paddings (HomeScreen + PerformanceLab) move to:
    max(72px, calc(env(safe-area-inset-top, 0px) + 24px))

  Hard floor of 72px guarantees clearance on every device — including
  the PWA case where env() returns 0 and the calc() collapses to 24px.
  When env() returns a real value (Dynamic Island ~59), the calc()
  (= 83px) wins via max(). Either branch reaches a sensible target.

Retro-picker loop — the real bug (root cause)

  The user's report — "missed workout flow keeps bringing up the same
  cardio days from last week" — turned out to be a write-side bug. Two
  sites, same mistake:

    components/ForgeApp.jsx → handleMarkDayDone (live retro tick path)
    lib/storage.js          → Days._foldLegacy (legacy-to-Day migration)

  Both did:
      const eff = W.getEffectiveOn(date);
      scheduledType = (eff && eff[dow]) ? eff[dow].type : null;
      Days.set(profile, date, { scheduledType, completedType: scheduledType });

  W.getEffectiveOn returns null when no schedule edit log exists — which
  is the most common state, because most users have never edited their
  schedule. Result:
    scheduledType = null
    completedType = null
    → entry written to Days store

  Days.manualTickDates filters with `entry.completedType && !entry.sessionId`.
  null completedType fails the truthy check. Entry is excluded from the
  retro picker's "what's been ticked" projection.

  Net effect: every retro tick + every legacy dayDone date migrated
  through the fold landed in the Day store but was invisible to the retro
  picker. The picker kept showing those dates as "missed" because, as
  far as it was concerned, they'd never been marked. User taps Mark ✓
  → looks like nothing happens → same days re-appear next open. Infinite
  loop.

  Fix in both sites:
      const eff = W.getEffectiveOn(date) || DEFAULT_WEEK;
      scheduledType = eff[dow]?.type || null;

  DEFAULT_WEEK is the static schedule from programme.js — what every
  user is implicitly following until they save a custom edit. Now
  scheduledType falls back to the right concrete value (zone2, cardio,
  hiit, etc) instead of null. completedType inherits, the truthy filter
  in manualTickDates passes, the date appears as ticked, the retro
  picker stops surfacing it. Tests updated (storage-days) to assert the
  correct fallback behaviour rather than the buggy null behaviour.

  storage.js imports WEEK from programme.js — verified no circular
  dependency (programme.js doesn't transitively import storage).

Sync (PWA vs Safari shows different state) — NOT addressed this commit

  Need to be honest: I don't yet have a precise diagnosis. Most likely
  explanation given evidence is iOS's PWA storage isolation (PWA install
  has its own localStorage container separate from Safari), so the
  apparent "0/12 in Safari" might be Safari's fresh-to-this-context
  state racing with blob pull rather than a sync code bug. The retro
  picker bug above WOULD have masked any blob data round-tripping
  correctly through the Day store though, so once this fix lands a
  proper re-test from a clean Safari session is worth doing before
  assuming the sync layer needs more work.

407 tests (one updated), lint, typecheck, build clean.


Claude-Session: https://claude.ai/code/session_01Gucgxvub2JW5XT1q9dhU8f